### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.1.tgz",
-			"integrity": "sha512-zHrOHAatEPJ59o2JIPlhgc9LX9mb8xFrqu4kiiul4w1IGMTtKn2lqRiGIRKU0or69NSLXNmqbCP9bNJIr/wB6Q==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.2.tgz",
+			"integrity": "sha512-fQRPOSrQfO3AG1JEOgScVrYhOfprZbhSKAjY4goESGPKMflWHxyQt8djo6EZhNjxCNIUAPtT75hkCN902SeYAw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2133,19 +2133,19 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "4.3.1",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/map-workspaces": "^2.0.0",
-				"@npmcli/metavuln-calculator": "^2.0.0",
+				"@npmcli/metavuln-calculator": "^3.0.0",
 				"@npmcli/move-file": "^1.1.0",
 				"@npmcli/name-from-folder": "^1.0.1",
 				"@npmcli/node-gyp": "^1.0.3",
 				"@npmcli/package-json": "^1.0.1",
-				"@npmcli/run-script": "^2.0.0",
+				"@npmcli/run-script": "^3.0.0",
 				"bin-links": "^3.0.0",
 				"cacache": "^15.0.3",
 				"common-ancestor-path": "^1.0.1",
@@ -2153,13 +2153,15 @@
 				"json-stringify-nice": "^1.1.4",
 				"mkdirp": "^1.0.4",
 				"mkdirp-infer-owner": "^2.0.0",
+				"nopt": "^5.0.0",
 				"npm-install-checks": "^4.0.0",
-				"npm-package-arg": "^8.1.5",
-				"npm-pick-manifest": "^6.1.0",
-				"npm-registry-fetch": "^12.0.1",
-				"pacote": "^12.0.2",
+				"npm-package-arg": "^9.0.0",
+				"npm-pick-manifest": "^7.0.0",
+				"npm-registry-fetch": "^13.0.0",
+				"npmlog": "^6.0.1",
+				"pacote": "^13.0.2",
 				"parse-conflict-json": "^2.0.1",
-				"proc-log": "^1.0.0",
+				"proc-log": "^2.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^1.0.1",
 				"read-package-json-fast": "^2.0.2",
@@ -2186,7 +2188,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2194,8 +2196,9 @@
 				"ini": "^2.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"nopt": "^5.0.0",
+				"proc-log": "^2.0.0",
 				"read-package-json-fast": "^2.0.3",
-				"semver": "^7.3.4",
+				"semver": "^7.3.5",
 				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
@@ -2226,18 +2229,30 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "2.1.0",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/promise-spawn": "^1.3.2",
-				"lru-cache": "^6.0.0",
+				"lru-cache": "^7.3.1",
 				"mkdirp": "^1.0.4",
-				"npm-pick-manifest": "^6.1.1",
+				"npm-pick-manifest": "^7.0.0",
+				"proc-log": "^2.0.0",
 				"promise-inflight": "^1.0.1",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
 				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/git/node_modules/lru-cache": {
+			"version": "7.3.1",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
@@ -2270,14 +2285,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^15.0.5",
+				"cacache": "^15.3.0",
 				"json-parse-even-better-errors": "^2.3.1",
-				"pacote": "^12.0.0",
-				"semver": "^7.3.2"
+				"pacote": "^13.0.1",
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
@@ -2322,14 +2337,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^1.0.2",
+				"@npmcli/node-gyp": "^1.0.3",
 				"@npmcli/promise-spawn": "^1.3.2",
-				"node-gyp": "^8.2.0",
-				"read-package-json-fast": "^2.0.1"
+				"node-gyp": "^8.4.1",
+				"read-package-json-fast": "^2.0.3"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/@tootallnate/once": {
@@ -2379,14 +2397,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/npm/node_modules/ansi-styles": {
@@ -2573,27 +2583,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/cli-columns/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/cli-columns/node_modules/string-width": {
-			"version": "4.2.3",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"inBundle": true,
@@ -2617,46 +2606,6 @@
 			},
 			"optionalDependencies": {
 				"colors": "1.4.0"
-			}
-		},
-		"node_modules/npm/node_modules/cli-table3/node_modules/ansi-regex": {
-			"version": "5.0.0",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/cli-table3/node_modules/string-width": {
-			"version": "4.2.2",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/cli-table3/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/clone": {
@@ -2712,12 +2661,34 @@
 			}
 		},
 		"node_modules/npm/node_modules/columnify": {
-			"version": "1.5.4",
+			"version": "1.6.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"strip-ansi": "^3.0.0",
+				"strip-ansi": "^6.0.1",
 				"wcwidth": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/columnify/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
@@ -2878,27 +2849,6 @@
 			"version": "5.0.1",
 			"inBundle": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/gauge/node_modules/string-width": {
-			"version": "4.2.3",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
 			"engines": {
 				"node": ">=8"
 			}
@@ -3078,20 +3028,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "2.0.5",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^8.1.5",
+				"npm-package-arg": "^9.0.0",
 				"promzard": "^0.3.0",
-				"read": "~1.0.1",
+				"read": "^1.0.7",
 				"read-package-json": "^4.1.1",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/ip": {
@@ -3130,11 +3080,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-fullwidth-code-point": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/is-lambda": {
@@ -3184,21 +3134,21 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
 				"minipass": "^3.1.1",
-				"npm-package-arg": "^8.1.2",
-				"npm-registry-fetch": "^12.0.1"
+				"npm-package-arg": "^9.0.0",
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3207,8 +3157,8 @@
 				"binary-extensions": "^2.2.0",
 				"diff": "^5.0.0",
 				"minimatch": "^3.0.4",
-				"npm-package-arg": "^8.1.4",
-				"pacote": "^12.0.0",
+				"npm-package-arg": "^9.0.0",
+				"pacote": "^13.0.2",
 				"tar": "^6.1.0"
 			},
 			"engines": {
@@ -3216,18 +3166,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "3.0.3",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^4.0.0",
+				"@npmcli/arborist": "^5.0.0",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/run-script": "^2.0.0",
+				"@npmcli/run-script": "^3.0.0",
 				"chalk": "^4.1.0",
 				"mkdirp-infer-owner": "^2.0.0",
-				"npm-package-arg": "^8.1.2",
-				"pacote": "^12.0.0",
-				"proc-log": "^1.0.0",
+				"npm-package-arg": "^9.0.0",
+				"npmlog": "^6.0.1",
+				"pacote": "^13.0.2",
+				"proc-log": "^2.0.0",
 				"read": "^1.0.7",
 				"read-package-json-fast": "^2.0.2",
 				"walk-up-path": "^1.0.0"
@@ -3237,61 +3188,61 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^4.0.0"
+				"@npmcli/arborist": "^5.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "7.0.1",
+			"version": "8.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^12.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^12.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "3.1.0",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/run-script": "^2.0.0",
-				"npm-package-arg": "^8.1.0",
-				"pacote": "^12.0.0"
+				"@npmcli/run-script": "^3.0.0",
+				"npm-package-arg": "^9.0.0",
+				"pacote": "^13.0.2"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"normalize-package-data": "^3.0.2",
-				"npm-package-arg": "^8.1.2",
-				"npm-registry-fetch": "^12.0.1",
+				"npm-package-arg": "^9.0.0",
+				"npm-registry-fetch": "^13.0.0",
 				"semver": "^7.1.3",
 				"ssri": "^8.0.1"
 			},
@@ -3300,36 +3251,37 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "4.0.1",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^12.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^12.0.1"
+				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^2.0.7",
-				"@npmcli/run-script": "^2.0.0",
+				"@npmcli/git": "^3.0.0",
+				"@npmcli/run-script": "^3.0.0",
 				"json-parse-even-better-errors": "^2.3.1",
+				"proc-log": "^2.0.0",
 				"semver": "^7.3.5",
 				"stringify-package": "^1.0.1"
 			},
@@ -3661,16 +3613,16 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "8.1.5",
+			"version": "9.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"semver": "^7.3.4",
+				"hosted-git-info": "^4.1.0",
+				"semver": "^7.3.5",
 				"validate-npm-package-name": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
@@ -3691,38 +3643,43 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "6.1.1",
+			"version": "7.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"npm-install-checks": "^4.0.0",
 				"npm-normalize-package-bin": "^1.0.1",
-				"npm-package-arg": "^8.1.2",
-				"semver": "^7.3.4"
+				"npm-package-arg": "^9.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "6.0.0",
+			"version": "6.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^12.0.0"
+				"npm-registry-fetch": "^13.0.0",
+				"proc-log": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "12.0.2",
+			"version": "13.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"make-fetch-happen": "^10.0.1",
+				"make-fetch-happen": "^10.0.2",
 				"minipass": "^3.1.6",
 				"minipass-fetch": "^1.4.1",
 				"minipass-json-stream": "^1.0.1",
 				"minizlib": "^2.1.2",
-				"npm-package-arg": "^8.1.5"
+				"npm-package-arg": "^9.0.0",
+				"proc-log": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
@@ -3778,29 +3735,31 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "12.0.3",
+			"version": "13.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^2.1.0",
-				"@npmcli/installed-package-contents": "^1.0.6",
+				"@npmcli/git": "^3.0.0",
+				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/promise-spawn": "^1.2.0",
-				"@npmcli/run-script": "^2.0.0",
-				"cacache": "^15.0.5",
+				"@npmcli/run-script": "^3.0.0",
+				"cacache": "^15.3.0",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
 				"infer-owner": "^1.0.4",
-				"minipass": "^3.1.3",
-				"mkdirp": "^1.0.3",
-				"npm-package-arg": "^8.0.1",
+				"minipass": "^3.1.6",
+				"mkdirp": "^1.0.4",
+				"npm-package-arg": "^9.0.0",
 				"npm-packlist": "^3.0.0",
-				"npm-pick-manifest": "^6.0.0",
-				"npm-registry-fetch": "^12.0.0",
+				"npm-pick-manifest": "^7.0.0",
+				"npm-registry-fetch": "^13.0.0",
+				"proc-log": "^2.0.0",
 				"promise-retry": "^2.0.1",
-				"read-package-json-fast": "^2.0.1",
+				"read-package-json": "^4.1.1",
+				"read-package-json-fast": "^2.0.3",
 				"rimraf": "^3.0.2",
 				"ssri": "^8.0.1",
-				"tar": "^6.1.0"
+				"tar": "^6.1.11"
 			},
 			"bin": {
 				"pacote": "lib/bin.js"
@@ -3831,9 +3790,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "1.0.0",
+			"version": "2.0.0",
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
+			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
 			"version": "1.0.1",
@@ -4103,51 +4065,41 @@
 			}
 		},
 		"node_modules/npm/node_modules/string-width": {
-			"version": "2.1.1",
+			"version": "4.2.3",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-			"version": "3.0.0",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
-			"version": "4.0.0",
+			"version": "6.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/stringify-package": {
 			"version": "1.0.1",
 			"inBundle": true,
 			"license": "ISC"
-		},
-		"node_modules/npm/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/npm/node_modules/supports-color": {
 			"version": "7.2.0",
@@ -5350,9 +5302,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
+			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -6973,9 +6925,9 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.1.tgz",
-			"integrity": "sha512-zHrOHAatEPJ59o2JIPlhgc9LX9mb8xFrqu4kiiul4w1IGMTtKn2lqRiGIRKU0or69NSLXNmqbCP9bNJIr/wB6Q==",
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.2.tgz",
+			"integrity": "sha512-fQRPOSrQfO3AG1JEOgScVrYhOfprZbhSKAjY4goESGPKMflWHxyQt8djo6EZhNjxCNIUAPtT75hkCN902SeYAw==",
 			"requires": {
 				"@isaacs/string-locale-compare": "*",
 				"@npmcli/arborist": "*",
@@ -7059,18 +7011,18 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "4.3.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/map-workspaces": "^2.0.0",
-						"@npmcli/metavuln-calculator": "^2.0.0",
+						"@npmcli/metavuln-calculator": "^3.0.0",
 						"@npmcli/move-file": "^1.1.0",
 						"@npmcli/name-from-folder": "^1.0.1",
 						"@npmcli/node-gyp": "^1.0.3",
 						"@npmcli/package-json": "^1.0.1",
-						"@npmcli/run-script": "^2.0.0",
+						"@npmcli/run-script": "^3.0.0",
 						"bin-links": "^3.0.0",
 						"cacache": "^15.0.3",
 						"common-ancestor-path": "^1.0.1",
@@ -7078,13 +7030,15 @@
 						"json-stringify-nice": "^1.1.4",
 						"mkdirp": "^1.0.4",
 						"mkdirp-infer-owner": "^2.0.0",
+						"nopt": "^5.0.0",
 						"npm-install-checks": "^4.0.0",
-						"npm-package-arg": "^8.1.5",
-						"npm-pick-manifest": "^6.1.0",
-						"npm-registry-fetch": "^12.0.1",
-						"pacote": "^12.0.2",
+						"npm-package-arg": "^9.0.0",
+						"npm-pick-manifest": "^7.0.0",
+						"npm-registry-fetch": "^13.0.0",
+						"npmlog": "^6.0.1",
+						"pacote": "^13.0.2",
 						"parse-conflict-json": "^2.0.1",
-						"proc-log": "^1.0.0",
+						"proc-log": "^2.0.0",
 						"promise-all-reject-late": "^1.0.0",
 						"promise-call-limit": "^1.0.1",
 						"read-package-json-fast": "^2.0.2",
@@ -7101,15 +7055,16 @@
 					"bundled": true
 				},
 				"@npmcli/config": {
-					"version": "3.0.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/map-workspaces": "^2.0.0",
 						"ini": "^2.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"nopt": "^5.0.0",
+						"proc-log": "^2.0.0",
 						"read-package-json-fast": "^2.0.3",
-						"semver": "^7.3.4",
+						"semver": "^7.3.5",
 						"walk-up-path": "^1.0.0"
 					}
 				},
@@ -7129,17 +7084,24 @@
 					}
 				},
 				"@npmcli/git": {
-					"version": "2.1.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/promise-spawn": "^1.3.2",
-						"lru-cache": "^6.0.0",
+						"lru-cache": "^7.3.1",
 						"mkdirp": "^1.0.4",
-						"npm-pick-manifest": "^6.1.1",
+						"npm-pick-manifest": "^7.0.0",
+						"proc-log": "^2.0.0",
 						"promise-inflight": "^1.0.1",
 						"promise-retry": "^2.0.1",
 						"semver": "^7.3.5",
 						"which": "^2.0.2"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "7.3.1",
+							"bundled": true
+						}
 					}
 				},
 				"@npmcli/installed-package-contents": {
@@ -7161,13 +7123,13 @@
 					}
 				},
 				"@npmcli/metavuln-calculator": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"cacache": "^15.0.5",
+						"cacache": "^15.3.0",
 						"json-parse-even-better-errors": "^2.3.1",
-						"pacote": "^12.0.0",
-						"semver": "^7.3.2"
+						"pacote": "^13.0.1",
+						"semver": "^7.3.5"
 					}
 				},
 				"@npmcli/move-file": {
@@ -7201,13 +7163,13 @@
 					}
 				},
 				"@npmcli/run-script": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/node-gyp": "^1.0.2",
+						"@npmcli/node-gyp": "^1.0.3",
 						"@npmcli/promise-spawn": "^1.3.2",
-						"node-gyp": "^8.2.0",
-						"read-package-json-fast": "^2.0.1"
+						"node-gyp": "^8.4.1",
+						"read-package-json-fast": "^2.0.3"
 					}
 				},
 				"@tootallnate/once": {
@@ -7241,10 +7203,6 @@
 						"clean-stack": "^2.0.0",
 						"indent-string": "^4.0.0"
 					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
 				},
 				"ansi-styles": {
 					"version": "4.3.0",
@@ -7372,19 +7330,6 @@
 							"version": "5.0.1",
 							"bundled": true
 						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "4.2.3",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.1"
-							}
-						},
 						"strip-ansi": {
 							"version": "6.0.1",
 							"bundled": true,
@@ -7400,32 +7345,6 @@
 					"requires": {
 						"colors": "1.4.0",
 						"string-width": "^4.2.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "4.2.2",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "6.0.0",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
 					}
 				},
 				"clone": {
@@ -7460,11 +7379,24 @@
 					"optional": true
 				},
 				"columnify": {
-					"version": "1.5.4",
+					"version": "1.6.0",
 					"bundled": true,
 					"requires": {
-						"strip-ansi": "^3.0.0",
+						"strip-ansi": "^6.0.1",
 						"wcwidth": "^1.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "5.0.1",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "6.0.1",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^5.0.1"
+							}
+						}
 					}
 				},
 				"common-ancestor-path": {
@@ -7580,19 +7512,6 @@
 						"ansi-regex": {
 							"version": "5.0.1",
 							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "3.0.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "4.2.3",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^8.0.0",
-								"is-fullwidth-code-point": "^3.0.0",
-								"strip-ansi": "^6.0.1"
-							}
 						},
 						"strip-ansi": {
 							"version": "6.0.1",
@@ -7713,12 +7632,12 @@
 					"bundled": true
 				},
 				"init-package-json": {
-					"version": "2.0.5",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"npm-package-arg": "^8.1.5",
+						"npm-package-arg": "^9.0.0",
 						"promzard": "^0.3.0",
-						"read": "~1.0.1",
+						"read": "^1.0.7",
 						"read-package-json": "^4.1.1",
 						"semver": "^7.3.5",
 						"validate-npm-package-license": "^3.0.4",
@@ -7748,7 +7667,7 @@
 					}
 				},
 				"is-fullwidth-code-point": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true
 				},
 				"is-lambda": {
@@ -7784,17 +7703,17 @@
 					"bundled": true
 				},
 				"libnpmaccess": {
-					"version": "5.0.1",
+					"version": "6.0.0",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
 						"minipass": "^3.1.1",
-						"npm-package-arg": "^8.1.2",
-						"npm-registry-fetch": "^12.0.1"
+						"npm-package-arg": "^9.0.0",
+						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmdiff": {
-					"version": "3.0.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/disparity-colors": "^1.0.1",
@@ -7802,93 +7721,95 @@
 						"binary-extensions": "^2.2.0",
 						"diff": "^5.0.0",
 						"minimatch": "^3.0.4",
-						"npm-package-arg": "^8.1.4",
-						"pacote": "^12.0.0",
+						"npm-package-arg": "^9.0.0",
+						"pacote": "^13.0.2",
 						"tar": "^6.1.0"
 					}
 				},
 				"libnpmexec": {
-					"version": "3.0.3",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^4.0.0",
+						"@npmcli/arborist": "^5.0.0",
 						"@npmcli/ci-detect": "^2.0.0",
-						"@npmcli/run-script": "^2.0.0",
+						"@npmcli/run-script": "^3.0.0",
 						"chalk": "^4.1.0",
 						"mkdirp-infer-owner": "^2.0.0",
-						"npm-package-arg": "^8.1.2",
-						"pacote": "^12.0.0",
-						"proc-log": "^1.0.0",
+						"npm-package-arg": "^9.0.0",
+						"npmlog": "^6.0.1",
+						"pacote": "^13.0.2",
+						"proc-log": "^2.0.0",
 						"read": "^1.0.7",
 						"read-package-json-fast": "^2.0.2",
 						"walk-up-path": "^1.0.0"
 					}
 				},
 				"libnpmfund": {
-					"version": "2.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^4.0.0"
+						"@npmcli/arborist": "^5.0.0"
 					}
 				},
 				"libnpmhook": {
-					"version": "7.0.1",
+					"version": "8.0.0",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
-						"npm-registry-fetch": "^12.0.1"
+						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmorg": {
-					"version": "3.0.1",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
-						"npm-registry-fetch": "^12.0.1"
+						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmpack": {
-					"version": "3.1.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/run-script": "^2.0.0",
-						"npm-package-arg": "^8.1.0",
-						"pacote": "^12.0.0"
+						"@npmcli/run-script": "^3.0.0",
+						"npm-package-arg": "^9.0.0",
+						"pacote": "^13.0.2"
 					}
 				},
 				"libnpmpublish": {
-					"version": "5.0.1",
+					"version": "6.0.0",
 					"bundled": true,
 					"requires": {
 						"normalize-package-data": "^3.0.2",
-						"npm-package-arg": "^8.1.2",
-						"npm-registry-fetch": "^12.0.1",
+						"npm-package-arg": "^9.0.0",
+						"npm-registry-fetch": "^13.0.0",
 						"semver": "^7.1.3",
 						"ssri": "^8.0.1"
 					}
 				},
 				"libnpmsearch": {
-					"version": "4.0.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"npm-registry-fetch": "^12.0.1"
+						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmteam": {
-					"version": "3.0.1",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
-						"npm-registry-fetch": "^12.0.1"
+						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmversion": {
-					"version": "2.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/git": "^2.0.7",
-						"@npmcli/run-script": "^2.0.0",
+						"@npmcli/git": "^3.0.0",
+						"@npmcli/run-script": "^3.0.0",
 						"json-parse-even-better-errors": "^2.3.1",
+						"proc-log": "^2.0.0",
 						"semver": "^7.3.5",
 						"stringify-package": "^1.0.1"
 					}
@@ -8117,11 +8038,11 @@
 					"bundled": true
 				},
 				"npm-package-arg": {
-					"version": "8.1.5",
+					"version": "9.0.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"semver": "^7.3.4",
+						"hosted-git-info": "^4.1.0",
+						"semver": "^7.3.5",
 						"validate-npm-package-name": "^3.0.0"
 					}
 				},
@@ -8136,32 +8057,34 @@
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "6.1.1",
+					"version": "7.0.0",
 					"bundled": true,
 					"requires": {
 						"npm-install-checks": "^4.0.0",
 						"npm-normalize-package-bin": "^1.0.1",
-						"npm-package-arg": "^8.1.2",
-						"semver": "^7.3.4"
+						"npm-package-arg": "^9.0.0",
+						"semver": "^7.3.5"
 					}
 				},
 				"npm-profile": {
-					"version": "6.0.0",
+					"version": "6.0.2",
 					"bundled": true,
 					"requires": {
-						"npm-registry-fetch": "^12.0.0"
+						"npm-registry-fetch": "^13.0.0",
+						"proc-log": "^2.0.0"
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "12.0.2",
+					"version": "13.0.0",
 					"bundled": true,
 					"requires": {
-						"make-fetch-happen": "^10.0.1",
+						"make-fetch-happen": "^10.0.2",
 						"minipass": "^3.1.6",
 						"minipass-fetch": "^1.4.1",
 						"minipass-json-stream": "^1.0.1",
 						"minizlib": "^2.1.2",
-						"npm-package-arg": "^8.1.5"
+						"npm-package-arg": "^9.0.0",
+						"proc-log": "^2.0.0"
 					}
 				},
 				"npm-user-validate": {
@@ -8197,28 +8120,30 @@
 					}
 				},
 				"pacote": {
-					"version": "12.0.3",
+					"version": "13.0.3",
 					"bundled": true,
 					"requires": {
-						"@npmcli/git": "^2.1.0",
-						"@npmcli/installed-package-contents": "^1.0.6",
+						"@npmcli/git": "^3.0.0",
+						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/promise-spawn": "^1.2.0",
-						"@npmcli/run-script": "^2.0.0",
-						"cacache": "^15.0.5",
+						"@npmcli/run-script": "^3.0.0",
+						"cacache": "^15.3.0",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
 						"infer-owner": "^1.0.4",
-						"minipass": "^3.1.3",
-						"mkdirp": "^1.0.3",
-						"npm-package-arg": "^8.0.1",
+						"minipass": "^3.1.6",
+						"mkdirp": "^1.0.4",
+						"npm-package-arg": "^9.0.0",
 						"npm-packlist": "^3.0.0",
-						"npm-pick-manifest": "^6.0.0",
-						"npm-registry-fetch": "^12.0.0",
+						"npm-pick-manifest": "^7.0.0",
+						"npm-registry-fetch": "^13.0.0",
+						"proc-log": "^2.0.0",
 						"promise-retry": "^2.0.1",
-						"read-package-json-fast": "^2.0.1",
+						"read-package-json": "^4.1.1",
+						"read-package-json-fast": "^2.0.3",
 						"rimraf": "^3.0.2",
 						"ssri": "^8.0.1",
-						"tar": "^6.1.0"
+						"tar": "^6.1.11"
 					}
 				},
 				"parse-conflict-json": {
@@ -8235,7 +8160,7 @@
 					"bundled": true
 				},
 				"proc-log": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true
 				},
 				"promise-all-reject-late": {
@@ -8412,22 +8337,23 @@
 					}
 				},
 				"string-width": {
-					"version": "2.1.1",
+					"version": "4.2.3",
 					"bundled": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "3.0.0",
+							"version": "5.0.1",
 							"bundled": true
 						},
 						"strip-ansi": {
-							"version": "4.0.0",
+							"version": "6.0.1",
 							"bundled": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "^5.0.1"
 							}
 						}
 					}
@@ -8435,13 +8361,6 @@
 				"stringify-package": {
 					"version": "1.0.1",
 					"bundled": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -9313,9 +9232,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.1.tgz",
-			"integrity": "sha512-FAGKF12fWdkpvNJZENacOH0e/83eG6JyVQyanIJaBXCN1J11TUQv1T1/z8S+Z0CG0ZPk1nPcreF/c7lrTd0TEQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
+			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._