### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,9 +361,9 @@
 			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
 		},
 		"node_modules/@semantic-release/npm": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
-			"integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+			"integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
 			"dependencies": {
 				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
@@ -5289,9 +5289,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5760,9 +5760,9 @@
 			}
 		},
 		"@semantic-release/npm": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
-			"integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
+			"integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
 			"requires": {
 				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
@@ -9226,9 +9226,9 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+			"integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
 			"dev": true
 		},
 		"uglify-js": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._