### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.5.2",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.2.tgz",
-			"integrity": "sha512-fQRPOSrQfO3AG1JEOgScVrYhOfprZbhSKAjY4goESGPKMflWHxyQt8djo6EZhNjxCNIUAPtT75hkCN902SeYAw==",
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.3.tgz",
+			"integrity": "sha512-O+1j66Alx7ZQgWnUSSTaz8rTqQrJnqNb8Num5uQw2vYvc2RrxLaX7cWtRkDhvkPIL8Nf2WU9gx1oSu268QConA==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2123,7 +2123,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@gar/promisify": {
-			"version": "1.1.2",
+			"version": "1.1.3",
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -2188,11 +2188,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^2.0.0",
+				"@npmcli/map-workspaces": "^2.0.1",
 				"ini": "^2.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"nopt": "^5.0.0",
@@ -2248,7 +2248,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git/node_modules/lru-cache": {
-			"version": "7.3.1",
+			"version": "7.4.0",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -2271,17 +2271,36 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/name-from-folder": "^1.0.1",
-				"glob": "^7.1.6",
-				"minimatch": "^3.0.4",
-				"read-package-json-fast": "^2.0.1"
+				"glob": "^7.2.0",
+				"minimatch": "^5.0.0",
+				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
@@ -2337,13 +2356,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/node-gyp": "^1.0.3",
 				"@npmcli/promise-spawn": "^1.3.2",
-				"node-gyp": "^8.4.1",
+				"node-gyp": "^9.0.0",
 				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
@@ -2375,7 +2394,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/agentkeepalive": {
-			"version": "4.2.0",
+			"version": "4.2.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2827,19 +2846,19 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/gauge": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.2",
-				"console-control-strings": "^1.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
 				"has-unicode": "^2.0.1",
-				"signal-exit": "^3.0.0",
+				"signal-exit": "^3.0.7",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.2"
+				"wide-align": "^1.1.5"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
@@ -3092,11 +3111,6 @@
 			"inBundle": true,
 			"license": "MIT"
 		},
-		"node_modules/npm/node_modules/is-typedarray": {
-			"version": "1.0.0",
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/isexe": {
 			"version": "2.0.0",
 			"inBundle": true,
@@ -3301,20 +3315,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.0.3",
+			"version": "10.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"agentkeepalive": "^4.2.0",
+				"agentkeepalive": "^4.2.1",
 				"cacache": "^15.3.0",
 				"http-cache-semantics": "^4.1.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"is-lambda": "^1.0.1",
-				"lru-cache": "^7.3.1",
+				"lru-cache": "^7.4.0",
 				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
-				"minipass-fetch": "^1.4.1",
+				"minipass-fetch": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.3",
@@ -3327,7 +3341,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen/node_modules/lru-cache": {
-			"version": "7.3.1",
+			"version": "7.4.0",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3335,7 +3349,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "3.0.4",
+			"version": "3.1.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3368,19 +3382,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "1.4.1",
+			"version": "2.0.2",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"minipass": "^3.1.0",
+				"minipass": "^3.1.6",
 				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.0.0"
+				"minizlib": "^2.1.2"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			},
 			"optionalDependencies": {
-				"encoding": "^0.1.12"
+				"encoding": "^0.1.13"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
@@ -3480,14 +3494,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "8.4.1",
+			"version": "9.0.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^9.1.0",
+				"make-fetch-happen": "^10.0.3",
 				"nopt": "^5.0.0",
 				"npmlog": "^6.0.0",
 				"rimraf": "^3.0.2",
@@ -3499,54 +3513,7 @@
 				"node-gyp": "bin/node-gyp.js"
 			},
 			"engines": {
-				"node": ">= 10.12.0"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/@tootallnate/once": {
-			"version": "1.1.2",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/http-proxy-agent": {
-			"version": "4.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"@tootallnate/once": "1",
-				"agent-base": "6",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-			"version": "9.1.0",
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"agentkeepalive": "^4.1.3",
-				"cacache": "^15.2.0",
-				"http-cache-semantics": "^4.1.0",
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"is-lambda": "^1.0.1",
-				"lru-cache": "^6.0.0",
-				"minipass": "^3.1.3",
-				"minipass-collect": "^1.0.2",
-				"minipass-fetch": "^1.3.2",
-				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.4",
-				"negotiator": "^0.6.2",
-				"promise-retry": "^2.0.1",
-				"socks-proxy-agent": "^6.0.0",
-				"ssri": "^8.0.0"
-			},
-			"engines": {
-				"node": ">= 10"
+				"node": "^12.22 || ^14.13 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/nopt": {
@@ -3669,13 +3636,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "13.0.0",
+			"version": "13.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"make-fetch-happen": "^10.0.2",
+				"make-fetch-happen": "^10.0.3",
 				"minipass": "^3.1.6",
-				"minipass-fetch": "^1.4.1",
+				"minipass-fetch": "^2.0.1",
 				"minipass-json-stream": "^1.0.1",
 				"minizlib": "^2.1.2",
 				"npm-package-arg": "^9.0.0",
@@ -3978,7 +3945,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/signal-exit": {
-			"version": "3.0.6",
+			"version": "3.0.7",
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -3992,12 +3959,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.6.1",
+			"version": "2.6.2",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"ip": "^1.1.5",
-				"smart-buffer": "^4.1.0"
+				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0",
@@ -4143,25 +4110,6 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/typedarray-to-buffer": {
-			"version": "4.0.0",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/unique-filename": {
 			"version": "1.1.1",
 			"inBundle": true,
@@ -4241,14 +4189,12 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^4.0.0"
+				"signal-exit": "^3.0.7"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
@@ -6925,9 +6871,9 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.5.2",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.2.tgz",
-			"integrity": "sha512-fQRPOSrQfO3AG1JEOgScVrYhOfprZbhSKAjY4goESGPKMflWHxyQt8djo6EZhNjxCNIUAPtT75hkCN902SeYAw==",
+			"version": "8.5.3",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.3.tgz",
+			"integrity": "sha512-O+1j66Alx7ZQgWnUSSTaz8rTqQrJnqNb8Num5uQw2vYvc2RrxLaX7cWtRkDhvkPIL8Nf2WU9gx1oSu268QConA==",
 			"requires": {
 				"@isaacs/string-locale-compare": "*",
 				"@npmcli/arborist": "*",
@@ -7003,7 +6949,7 @@
 			},
 			"dependencies": {
 				"@gar/promisify": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true
 				},
 				"@isaacs/string-locale-compare": {
@@ -7055,10 +7001,10 @@
 					"bundled": true
 				},
 				"@npmcli/config": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
-						"@npmcli/map-workspaces": "^2.0.0",
+						"@npmcli/map-workspaces": "^2.0.1",
 						"ini": "^2.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"nopt": "^5.0.0",
@@ -7099,7 +7045,7 @@
 					},
 					"dependencies": {
 						"lru-cache": {
-							"version": "7.3.1",
+							"version": "7.4.0",
 							"bundled": true
 						}
 					}
@@ -7113,13 +7059,29 @@
 					}
 				},
 				"@npmcli/map-workspaces": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/name-from-folder": "^1.0.1",
-						"glob": "^7.1.6",
-						"minimatch": "^3.0.4",
-						"read-package-json-fast": "^2.0.1"
+						"glob": "^7.2.0",
+						"minimatch": "^5.0.0",
+						"read-package-json-fast": "^2.0.3"
+					},
+					"dependencies": {
+						"brace-expansion": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0"
+							}
+						},
+						"minimatch": {
+							"version": "5.0.1",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^2.0.1"
+							}
+						}
 					}
 				},
 				"@npmcli/metavuln-calculator": {
@@ -7163,12 +7125,12 @@
 					}
 				},
 				"@npmcli/run-script": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/node-gyp": "^1.0.3",
 						"@npmcli/promise-spawn": "^1.3.2",
-						"node-gyp": "^8.4.1",
+						"node-gyp": "^9.0.0",
 						"read-package-json-fast": "^2.0.3"
 					}
 				},
@@ -7188,7 +7150,7 @@
 					}
 				},
 				"agentkeepalive": {
-					"version": "4.2.0",
+					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
 						"debug": "^4.1.0",
@@ -7495,18 +7457,18 @@
 					"bundled": true
 				},
 				"gauge": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"ansi-regex": "^5.0.1",
 						"aproba": "^1.0.3 || ^2.0.0",
-						"color-support": "^1.1.2",
-						"console-control-strings": "^1.0.0",
+						"color-support": "^1.1.3",
+						"console-control-strings": "^1.1.0",
 						"has-unicode": "^2.0.1",
-						"signal-exit": "^3.0.0",
+						"signal-exit": "^3.0.7",
 						"string-width": "^4.2.3",
 						"strip-ansi": "^6.0.1",
-						"wide-align": "^1.1.2"
+						"wide-align": "^1.1.5"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -7674,10 +7636,6 @@
 					"version": "1.0.1",
 					"bundled": true
 				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
 				"isexe": {
 					"version": "2.0.0",
 					"bundled": true
@@ -7822,19 +7780,19 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "10.0.3",
+					"version": "10.0.4",
 					"bundled": true,
 					"requires": {
-						"agentkeepalive": "^4.2.0",
+						"agentkeepalive": "^4.2.1",
 						"cacache": "^15.3.0",
 						"http-cache-semantics": "^4.1.0",
 						"http-proxy-agent": "^5.0.0",
 						"https-proxy-agent": "^5.0.0",
 						"is-lambda": "^1.0.1",
-						"lru-cache": "^7.3.1",
+						"lru-cache": "^7.4.0",
 						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
-						"minipass-fetch": "^1.4.1",
+						"minipass-fetch": "^2.0.1",
 						"minipass-flush": "^1.0.5",
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.3",
@@ -7844,13 +7802,13 @@
 					},
 					"dependencies": {
 						"lru-cache": {
-							"version": "7.3.1",
+							"version": "7.4.0",
 							"bundled": true
 						}
 					}
 				},
 				"minimatch": {
-					"version": "3.0.4",
+					"version": "3.1.2",
 					"bundled": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -7871,13 +7829,13 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "1.4.1",
+					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
-						"encoding": "^0.1.12",
-						"minipass": "^3.1.0",
+						"encoding": "^0.1.13",
+						"minipass": "^3.1.6",
 						"minipass-sized": "^1.0.3",
-						"minizlib": "^2.0.0"
+						"minizlib": "^2.1.2"
 					}
 				},
 				"minipass-flush": {
@@ -7943,56 +7901,19 @@
 					"bundled": true
 				},
 				"node-gyp": {
-					"version": "8.4.1",
+					"version": "9.0.0",
 					"bundled": true,
 					"requires": {
 						"env-paths": "^2.2.0",
 						"glob": "^7.1.4",
 						"graceful-fs": "^4.2.6",
-						"make-fetch-happen": "^9.1.0",
+						"make-fetch-happen": "^10.0.3",
 						"nopt": "^5.0.0",
 						"npmlog": "^6.0.0",
 						"rimraf": "^3.0.2",
 						"semver": "^7.3.5",
 						"tar": "^6.1.2",
 						"which": "^2.0.2"
-					},
-					"dependencies": {
-						"@tootallnate/once": {
-							"version": "1.1.2",
-							"bundled": true
-						},
-						"http-proxy-agent": {
-							"version": "4.0.1",
-							"bundled": true,
-							"requires": {
-								"@tootallnate/once": "1",
-								"agent-base": "6",
-								"debug": "4"
-							}
-						},
-						"make-fetch-happen": {
-							"version": "9.1.0",
-							"bundled": true,
-							"requires": {
-								"agentkeepalive": "^4.1.3",
-								"cacache": "^15.2.0",
-								"http-cache-semantics": "^4.1.0",
-								"http-proxy-agent": "^4.0.1",
-								"https-proxy-agent": "^5.0.0",
-								"is-lambda": "^1.0.1",
-								"lru-cache": "^6.0.0",
-								"minipass": "^3.1.3",
-								"minipass-collect": "^1.0.2",
-								"minipass-fetch": "^1.3.2",
-								"minipass-flush": "^1.0.5",
-								"minipass-pipeline": "^1.2.4",
-								"negotiator": "^0.6.2",
-								"promise-retry": "^2.0.1",
-								"socks-proxy-agent": "^6.0.0",
-								"ssri": "^8.0.0"
-							}
-						}
 					}
 				},
 				"nopt": {
@@ -8075,12 +7996,12 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "13.0.0",
+					"version": "13.0.1",
 					"bundled": true,
 					"requires": {
-						"make-fetch-happen": "^10.0.2",
+						"make-fetch-happen": "^10.0.3",
 						"minipass": "^3.1.6",
-						"minipass-fetch": "^1.4.1",
+						"minipass-fetch": "^2.0.1",
 						"minipass-json-stream": "^1.0.1",
 						"minizlib": "^2.1.2",
 						"npm-package-arg": "^9.0.0",
@@ -8274,7 +8195,7 @@
 					"bundled": true
 				},
 				"signal-exit": {
-					"version": "3.0.6",
+					"version": "3.0.7",
 					"bundled": true
 				},
 				"smart-buffer": {
@@ -8282,11 +8203,11 @@
 					"bundled": true
 				},
 				"socks": {
-					"version": "2.6.1",
+					"version": "2.6.2",
 					"bundled": true,
 					"requires": {
 						"ip": "^1.1.5",
-						"smart-buffer": "^4.1.0"
+						"smart-buffer": "^4.2.0"
 					}
 				},
 				"socks-proxy-agent": {
@@ -8393,10 +8314,6 @@
 					"version": "1.0.4",
 					"bundled": true
 				},
-				"typedarray-to-buffer": {
-					"version": "4.0.0",
-					"bundled": true
-				},
 				"unique-filename": {
 					"version": "1.1.1",
 					"bundled": true,
@@ -8460,13 +8377,11 @@
 					"bundled": true
 				},
 				"write-file-atomic": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"imurmurhash": "^0.1.4",
-						"is-typedarray": "^1.0.0",
-						"signal-exit": "^3.0.2",
-						"typedarray-to-buffer": "^4.0.0"
+						"signal-exit": "^3.0.7"
 					}
 				},
 				"yallist": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._