### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -613,9 +613,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
-			"integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -5248,9 +5248,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
-			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -5898,9 +5898,9 @@
 			}
 		},
 		"chalk": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
-			"integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -9147,9 +9147,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.2",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.2.tgz",
-			"integrity": "sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
+			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._