### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,13 +187,13 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-			"integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+			"integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
 			"dependencies": {
 				"@octokit/auth-token": "^2.4.4",
 				"@octokit/graphql": "^4.5.8",
-				"@octokit/request": "^5.6.0",
+				"@octokit/request": "^5.6.3",
 				"@octokit/request-error": "^2.0.5",
 				"@octokit/types": "^6.0.3",
 				"before-after-hook": "^2.2.0",
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.3.tgz",
-			"integrity": "sha512-O+1j66Alx7ZQgWnUSSTaz8rTqQrJnqNb8Num5uQw2vYvc2RrxLaX7cWtRkDhvkPIL8Nf2WU9gx1oSu268QConA==",
+			"version": "8.5.4",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.4.tgz",
+			"integrity": "sha512-VnGLT4t88cUE78lLw5kxBwtLn2/Sx6O7Uw9dYwmq6AnF/taWHyMYQgDzUEsLhaXAVH7prG+sjG+MvxlHdIasgg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2133,7 +2133,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.0.0",
+			"version": "5.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2271,13 +2271,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/name-from-folder": "^1.0.1",
 				"glob": "^7.2.0",
-				"minimatch": "^5.0.0",
+				"minimatch": "^5.0.1",
 				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
@@ -2846,11 +2846,10 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/gauge": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ansi-regex": "^5.0.1",
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.3",
 				"console-control-strings": "^1.1.0",
@@ -3148,7 +3147,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "6.0.0",
+			"version": "6.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3162,7 +3161,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3180,7 +3179,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3202,7 +3201,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3213,7 +3212,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "8.0.0",
+			"version": "8.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3225,7 +3224,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3237,7 +3236,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3250,7 +3249,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.0",
+			"version": "6.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3265,7 +3264,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3276,7 +3275,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3288,7 +3287,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3315,7 +3314,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.0.4",
+			"version": "10.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3325,10 +3324,10 @@
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"is-lambda": "^1.0.1",
-				"lru-cache": "^7.4.0",
+				"lru-cache": "^7.4.1",
 				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
-				"minipass-fetch": "^2.0.1",
+				"minipass-fetch": "^2.0.2",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.3",
@@ -3341,7 +3340,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen/node_modules/lru-cache": {
-			"version": "7.4.0",
+			"version": "7.4.2",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3829,7 +3828,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "4.1.1",
+			"version": "4.1.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -5553,13 +5552,13 @@
 			}
 		},
 		"@octokit/core": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-			"integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+			"integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
 			"requires": {
 				"@octokit/auth-token": "^2.4.4",
 				"@octokit/graphql": "^4.5.8",
-				"@octokit/request": "^5.6.0",
+				"@octokit/request": "^5.6.3",
 				"@octokit/request-error": "^2.0.5",
 				"@octokit/types": "^6.0.3",
 				"before-after-hook": "^2.2.0",
@@ -6871,9 +6870,9 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.3.tgz",
-			"integrity": "sha512-O+1j66Alx7ZQgWnUSSTaz8rTqQrJnqNb8Num5uQw2vYvc2RrxLaX7cWtRkDhvkPIL8Nf2WU9gx1oSu268QConA==",
+			"version": "8.5.4",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.4.tgz",
+			"integrity": "sha512-VnGLT4t88cUE78lLw5kxBwtLn2/Sx6O7Uw9dYwmq6AnF/taWHyMYQgDzUEsLhaXAVH7prG+sjG+MvxlHdIasgg==",
 			"requires": {
 				"@isaacs/string-locale-compare": "*",
 				"@npmcli/arborist": "*",
@@ -6957,7 +6956,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.0.0",
+					"version": "5.0.2",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -7059,12 +7058,12 @@
 					}
 				},
 				"@npmcli/map-workspaces": {
-					"version": "2.0.1",
+					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/name-from-folder": "^1.0.1",
 						"glob": "^7.2.0",
-						"minimatch": "^5.0.0",
+						"minimatch": "^5.0.1",
 						"read-package-json-fast": "^2.0.3"
 					},
 					"dependencies": {
@@ -7457,10 +7456,9 @@
 					"bundled": true
 				},
 				"gauge": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
-						"ansi-regex": "^5.0.1",
 						"aproba": "^1.0.3 || ^2.0.0",
 						"color-support": "^1.1.3",
 						"console-control-strings": "^1.1.0",
@@ -7661,7 +7659,7 @@
 					"bundled": true
 				},
 				"libnpmaccess": {
-					"version": "6.0.0",
+					"version": "6.0.1",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7671,7 +7669,7 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/disparity-colors": "^1.0.1",
@@ -7685,7 +7683,7 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0",
@@ -7703,14 +7701,14 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0"
 					}
 				},
 				"libnpmhook": {
-					"version": "8.0.0",
+					"version": "8.0.1",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7718,7 +7716,7 @@
 					}
 				},
 				"libnpmorg": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7726,7 +7724,7 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/run-script": "^3.0.0",
@@ -7735,7 +7733,7 @@
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.0",
+					"version": "6.0.1",
 					"bundled": true,
 					"requires": {
 						"normalize-package-data": "^3.0.2",
@@ -7746,14 +7744,14 @@
 					}
 				},
 				"libnpmsearch": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
 						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmteam": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7761,7 +7759,7 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
@@ -7780,7 +7778,7 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "10.0.4",
+					"version": "10.0.5",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
@@ -7789,10 +7787,10 @@
 						"http-proxy-agent": "^5.0.0",
 						"https-proxy-agent": "^5.0.0",
 						"is-lambda": "^1.0.1",
-						"lru-cache": "^7.4.0",
+						"lru-cache": "^7.4.1",
 						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
-						"minipass-fetch": "^2.0.1",
+						"minipass-fetch": "^2.0.2",
 						"minipass-flush": "^1.0.5",
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.3",
@@ -7802,7 +7800,7 @@
 					},
 					"dependencies": {
 						"lru-cache": {
-							"version": "7.4.0",
+							"version": "7.4.2",
 							"bundled": true
 						}
 					}
@@ -8127,7 +8125,7 @@
 					"bundled": true
 				},
 				"read-package-json": {
-					"version": "4.1.1",
+					"version": "4.1.2",
 					"bundled": true,
 					"requires": {
 						"glob": "^7.1.1",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._