### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
 			}
 		},
 		"node_modules/@actions/exec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
-			"integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+			"integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
 			"dependencies": {
 				"@actions/io": "^1.0.1"
 			}
@@ -54,9 +54,9 @@
 			}
 		},
 		"node_modules/@actions/io": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
-			"integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
+			"integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.16.7",
@@ -817,9 +817,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.4.tgz",
-			"integrity": "sha512-VnGLT4t88cUE78lLw5kxBwtLn2/Sx6O7Uw9dYwmq6AnF/taWHyMYQgDzUEsLhaXAVH7prG+sjG+MvxlHdIasgg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
+			"integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2031,77 +2031,77 @@
 				"write-file-atomic"
 			],
 			"dependencies": {
-				"@isaacs/string-locale-compare": "*",
-				"@npmcli/arborist": "*",
-				"@npmcli/ci-detect": "*",
-				"@npmcli/config": "*",
-				"@npmcli/map-workspaces": "*",
-				"@npmcli/package-json": "*",
-				"@npmcli/run-script": "*",
-				"abbrev": "*",
-				"ansicolors": "*",
-				"ansistyles": "*",
-				"archy": "*",
-				"cacache": "*",
-				"chalk": "*",
-				"chownr": "*",
-				"cli-columns": "*",
-				"cli-table3": "*",
-				"columnify": "*",
-				"fastest-levenshtein": "*",
-				"glob": "*",
-				"graceful-fs": "*",
-				"hosted-git-info": "*",
-				"ini": "*",
-				"init-package-json": "*",
-				"is-cidr": "*",
-				"json-parse-even-better-errors": "*",
-				"libnpmaccess": "*",
-				"libnpmdiff": "*",
-				"libnpmexec": "*",
-				"libnpmfund": "*",
-				"libnpmhook": "*",
-				"libnpmorg": "*",
-				"libnpmpack": "*",
-				"libnpmpublish": "*",
-				"libnpmsearch": "*",
-				"libnpmteam": "*",
-				"libnpmversion": "*",
-				"make-fetch-happen": "*",
-				"minipass": "*",
-				"minipass-pipeline": "*",
-				"mkdirp": "*",
-				"mkdirp-infer-owner": "*",
-				"ms": "*",
-				"node-gyp": "*",
-				"nopt": "*",
-				"npm-audit-report": "*",
-				"npm-install-checks": "*",
-				"npm-package-arg": "*",
-				"npm-pick-manifest": "*",
-				"npm-profile": "*",
-				"npm-registry-fetch": "*",
-				"npm-user-validate": "*",
-				"npmlog": "*",
-				"opener": "*",
-				"pacote": "*",
-				"parse-conflict-json": "*",
-				"proc-log": "*",
-				"qrcode-terminal": "*",
-				"read": "*",
-				"read-package-json": "*",
-				"read-package-json-fast": "*",
-				"readdir-scoped-modules": "*",
-				"rimraf": "*",
-				"semver": "*",
-				"ssri": "*",
-				"tar": "*",
-				"text-table": "*",
-				"tiny-relative-date": "*",
-				"treeverse": "*",
-				"validate-npm-package-name": "*",
-				"which": "*",
-				"write-file-atomic": "*"
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^5.0.3",
+				"@npmcli/ci-detect": "^2.0.0",
+				"@npmcli/config": "^4.0.1",
+				"@npmcli/map-workspaces": "^2.0.2",
+				"@npmcli/package-json": "^1.0.1",
+				"@npmcli/run-script": "^3.0.1",
+				"abbrev": "~1.1.1",
+				"ansicolors": "~0.3.2",
+				"ansistyles": "~0.1.3",
+				"archy": "~1.0.0",
+				"cacache": "^16.0.2",
+				"chalk": "^4.1.2",
+				"chownr": "^2.0.0",
+				"cli-columns": "^4.0.0",
+				"cli-table3": "^0.6.1",
+				"columnify": "^1.6.0",
+				"fastest-levenshtein": "^1.0.12",
+				"glob": "^7.2.0",
+				"graceful-fs": "^4.2.9",
+				"hosted-git-info": "^5.0.0",
+				"ini": "^2.0.0",
+				"init-package-json": "^3.0.1",
+				"is-cidr": "^4.0.2",
+				"json-parse-even-better-errors": "^2.3.1",
+				"libnpmaccess": "^6.0.2",
+				"libnpmdiff": "^4.0.2",
+				"libnpmexec": "^4.0.2",
+				"libnpmfund": "^3.0.1",
+				"libnpmhook": "^8.0.2",
+				"libnpmorg": "^4.0.2",
+				"libnpmpack": "^4.0.2",
+				"libnpmpublish": "^6.0.2",
+				"libnpmsearch": "^5.0.2",
+				"libnpmteam": "^4.0.2",
+				"libnpmversion": "^3.0.1",
+				"make-fetch-happen": "^10.0.6",
+				"minipass": "^3.1.6",
+				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
+				"mkdirp-infer-owner": "^2.0.0",
+				"ms": "^2.1.2",
+				"node-gyp": "^9.0.0",
+				"nopt": "^5.0.0",
+				"npm-audit-report": "^2.1.5",
+				"npm-install-checks": "^4.0.0",
+				"npm-package-arg": "^9.0.1",
+				"npm-pick-manifest": "^7.0.0",
+				"npm-profile": "^6.0.2",
+				"npm-registry-fetch": "^13.0.1",
+				"npm-user-validate": "^1.0.1",
+				"npmlog": "^6.0.1",
+				"opener": "^1.5.2",
+				"pacote": "^13.0.5",
+				"parse-conflict-json": "^2.0.1",
+				"proc-log": "^2.0.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "~1.0.7",
+				"read-package-json": "^5.0.0",
+				"read-package-json-fast": "^2.0.3",
+				"readdir-scoped-modules": "^1.1.0",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"ssri": "^8.0.1",
+				"tar": "^6.1.11",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^1.0.4",
+				"validate-npm-package-name": "~3.0.0",
+				"which": "^2.0.2",
+				"write-file-atomic": "^4.0.1"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
@@ -2133,21 +2133,21 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.0.2",
+			"version": "5.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/map-workspaces": "^2.0.0",
-				"@npmcli/metavuln-calculator": "^3.0.0",
+				"@npmcli/metavuln-calculator": "^3.0.1",
 				"@npmcli/move-file": "^1.1.0",
 				"@npmcli/name-from-folder": "^1.0.1",
 				"@npmcli/node-gyp": "^1.0.3",
 				"@npmcli/package-json": "^1.0.1",
 				"@npmcli/run-script": "^3.0.0",
 				"bin-links": "^3.0.0",
-				"cacache": "^15.0.3",
+				"cacache": "^16.0.0",
 				"common-ancestor-path": "^1.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
@@ -2159,7 +2159,7 @@
 				"npm-pick-manifest": "^7.0.0",
 				"npm-registry-fetch": "^13.0.0",
 				"npmlog": "^6.0.1",
-				"pacote": "^13.0.2",
+				"pacote": "^13.0.5",
 				"parse-conflict-json": "^2.0.1",
 				"proc-log": "^2.0.0",
 				"promise-all-reject-late": "^1.0.0",
@@ -2247,14 +2247,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
-		"node_modules/npm/node_modules/@npmcli/git/node_modules/lru-cache": {
-			"version": "7.4.0",
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
 			"version": "1.0.7",
 			"inBundle": true,
@@ -2304,13 +2296,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^15.3.0",
+				"cacache": "^16.0.0",
 				"json-parse-even-better-errors": "^2.3.1",
-				"pacote": "^13.0.1",
+				"pacote": "^13.0.3",
 				"semver": "^7.3.5"
 			},
 			"engines": {
@@ -2418,6 +2410,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/npm/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"inBundle": true,
@@ -2513,31 +2513,31 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "15.3.0",
+			"version": "16.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/fs": "^1.0.0",
-				"@npmcli/move-file": "^1.0.1",
+				"@npmcli/move-file": "^1.1.2",
 				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"glob": "^7.1.4",
+				"fs-minipass": "^2.1.0",
+				"glob": "^7.2.0",
 				"infer-owner": "^1.0.4",
-				"lru-cache": "^6.0.0",
-				"minipass": "^3.1.1",
+				"lru-cache": "^7.5.1",
+				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
 				"minipass-flush": "^1.0.5",
-				"minipass-pipeline": "^1.2.2",
-				"mkdirp": "^1.0.3",
+				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
 				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^3.0.2",
 				"ssri": "^8.0.1",
-				"tar": "^6.0.2",
+				"tar": "^6.1.11",
 				"unique-filename": "^1.1.1"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
@@ -2592,25 +2592,6 @@
 			},
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/cli-table3": {
@@ -2689,25 +2670,6 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/columnify/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
@@ -2863,25 +2825,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
-		"node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm/node_modules/glob": {
 			"version": "7.2.0",
 			"inBundle": true,
@@ -2931,14 +2874,14 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "4.1.0",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -3046,14 +2989,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"npm-package-arg": "^9.0.0",
 				"promzard": "^0.3.0",
 				"read": "^1.0.7",
-				"read-package-json": "^4.1.1",
+				"read-package-json": "^5.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
 				"validate-npm-package-name": "^3.0.0"
@@ -3147,13 +3090,13 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "6.0.1",
+			"version": "6.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
 				"minipass": "^3.1.1",
-				"npm-package-arg": "^9.0.0",
+				"npm-package-arg": "^9.0.1",
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
@@ -3161,7 +3104,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3170,8 +3113,8 @@
 				"binary-extensions": "^2.2.0",
 				"diff": "^5.0.0",
 				"minimatch": "^3.0.4",
-				"npm-package-arg": "^9.0.0",
-				"pacote": "^13.0.2",
+				"npm-package-arg": "^9.0.1",
+				"pacote": "^13.0.5",
 				"tar": "^6.1.0"
 			},
 			"engines": {
@@ -3179,7 +3122,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3188,9 +3131,9 @@
 				"@npmcli/run-script": "^3.0.0",
 				"chalk": "^4.1.0",
 				"mkdirp-infer-owner": "^2.0.0",
-				"npm-package-arg": "^9.0.0",
+				"npm-package-arg": "^9.0.1",
 				"npmlog": "^6.0.1",
-				"pacote": "^13.0.2",
+				"pacote": "^13.0.5",
 				"proc-log": "^2.0.0",
 				"read": "^1.0.7",
 				"read-package-json-fast": "^2.0.2",
@@ -3212,7 +3155,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "8.0.1",
+			"version": "8.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3224,7 +3167,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3236,25 +3179,25 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/run-script": "^3.0.0",
-				"npm-package-arg": "^9.0.0",
-				"pacote": "^13.0.2"
+				"npm-package-arg": "^9.0.1",
+				"pacote": "^13.0.5"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.1",
+			"version": "6.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"normalize-package-data": "^3.0.2",
-				"npm-package-arg": "^9.0.0",
+				"normalize-package-data": "^4.0.0",
+				"npm-package-arg": "^9.0.1",
 				"npm-registry-fetch": "^13.0.0",
 				"semver": "^7.1.3",
 				"ssri": "^8.0.1"
@@ -3264,7 +3207,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "5.0.1",
+			"version": "5.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3275,7 +3218,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3303,31 +3246,28 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "6.0.0",
+			"version": "7.5.1",
 			"inBundle": true,
 			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.0.5",
+			"version": "10.0.6",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.2.1",
-				"cacache": "^15.3.0",
+				"cacache": "^16.0.0",
 				"http-cache-semantics": "^4.1.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"is-lambda": "^1.0.1",
-				"lru-cache": "^7.4.1",
+				"lru-cache": "^7.5.1",
 				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
-				"minipass-fetch": "^2.0.2",
+				"minipass-fetch": "^2.0.3",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.3",
@@ -3337,14 +3277,6 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
-			}
-		},
-		"node_modules/npm/node_modules/make-fetch-happen/node_modules/lru-cache": {
-			"version": "7.4.2",
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
@@ -3381,7 +3313,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "2.0.2",
+			"version": "2.0.3",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3530,17 +3462,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "3.0.3",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "^5.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
@@ -3579,11 +3511,11 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "9.0.0",
+			"version": "9.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^4.1.0",
+				"hosted-git-info": "^5.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-name": "^3.0.0"
 			},
@@ -3592,20 +3524,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^7.1.6",
+				"glob": "^7.2.0",
 				"ignore-walk": "^4.0.1",
-				"npm-bundled": "^1.1.1",
+				"npm-bundled": "^1.1.2",
 				"npm-normalize-package-bin": "^1.0.1"
 			},
 			"bin": {
 				"npm-packlist": "bin/index.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
@@ -3701,27 +3633,27 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.0.3",
+			"version": "13.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/git": "^3.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/promise-spawn": "^1.2.0",
-				"@npmcli/run-script": "^3.0.0",
-				"cacache": "^15.3.0",
+				"@npmcli/run-script": "^3.0.1",
+				"cacache": "^16.0.0",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
 				"infer-owner": "^1.0.4",
 				"minipass": "^3.1.6",
 				"mkdirp": "^1.0.4",
 				"npm-package-arg": "^9.0.0",
-				"npm-packlist": "^3.0.0",
+				"npm-packlist": "^4.0.0",
 				"npm-pick-manifest": "^7.0.0",
-				"npm-registry-fetch": "^13.0.0",
+				"npm-registry-fetch": "^13.0.1",
 				"proc-log": "^2.0.0",
 				"promise-retry": "^2.0.1",
-				"read-package-json": "^4.1.1",
+				"read-package-json": "^5.0.0",
 				"read-package-json-fast": "^2.0.3",
 				"rimraf": "^3.0.2",
 				"ssri": "^8.0.1",
@@ -3828,17 +3760,17 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "4.1.2",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^7.1.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"normalize-package-data": "^3.0.0",
-				"npm-normalize-package-bin": "^1.0.0"
+				"glob": "^7.2.0",
+				"json-parse-even-better-errors": "^2.3.1",
+				"normalize-package-data": "^4.0.0",
+				"npm-normalize-package-bin": "^1.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json-fast": {
@@ -3933,6 +3865,17 @@
 			},
 			"bin": {
 				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -4043,15 +3986,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-			"version": "5.0.1",
+		"node_modules/npm/node_modules/stringify-package": {
+			"version": "1.0.1",
 			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
+			"license": "ISC"
 		},
-		"node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+		"node_modules/npm/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"inBundle": true,
 			"license": "MIT",
@@ -4061,11 +4001,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/npm/node_modules/stringify-package": {
-			"version": "1.0.1",
-			"inBundle": true,
-			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/supports-color": {
 			"version": "7.2.0",
@@ -5420,9 +5355,9 @@
 			}
 		},
 		"@actions/exec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
-			"integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+			"integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
 			"requires": {
 				"@actions/io": "^1.0.1"
 			}
@@ -5447,9 +5382,9 @@
 			}
 		},
 		"@actions/io": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
-			"integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.2.tgz",
+			"integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
 		},
 		"@babel/code-frame": {
 			"version": "7.16.7",
@@ -6050,9 +5985,9 @@
 			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -6870,81 +6805,81 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.4.tgz",
-			"integrity": "sha512-VnGLT4t88cUE78lLw5kxBwtLn2/Sx6O7Uw9dYwmq6AnF/taWHyMYQgDzUEsLhaXAVH7prG+sjG+MvxlHdIasgg==",
+			"version": "8.5.5",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
+			"integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
 			"requires": {
-				"@isaacs/string-locale-compare": "*",
-				"@npmcli/arborist": "*",
-				"@npmcli/ci-detect": "*",
-				"@npmcli/config": "*",
-				"@npmcli/map-workspaces": "*",
-				"@npmcli/package-json": "*",
-				"@npmcli/run-script": "*",
-				"abbrev": "*",
-				"ansicolors": "*",
-				"ansistyles": "*",
-				"archy": "*",
-				"cacache": "*",
-				"chalk": "*",
-				"chownr": "*",
-				"cli-columns": "*",
-				"cli-table3": "*",
-				"columnify": "*",
-				"fastest-levenshtein": "*",
-				"glob": "*",
-				"graceful-fs": "*",
-				"hosted-git-info": "*",
-				"ini": "*",
-				"init-package-json": "*",
-				"is-cidr": "*",
-				"json-parse-even-better-errors": "*",
-				"libnpmaccess": "*",
-				"libnpmdiff": "*",
-				"libnpmexec": "*",
-				"libnpmfund": "*",
-				"libnpmhook": "*",
-				"libnpmorg": "*",
-				"libnpmpack": "*",
-				"libnpmpublish": "*",
-				"libnpmsearch": "*",
-				"libnpmteam": "*",
-				"libnpmversion": "*",
-				"make-fetch-happen": "*",
-				"minipass": "*",
-				"minipass-pipeline": "*",
-				"mkdirp": "*",
-				"mkdirp-infer-owner": "*",
-				"ms": "*",
-				"node-gyp": "*",
-				"nopt": "*",
-				"npm-audit-report": "*",
-				"npm-install-checks": "*",
-				"npm-package-arg": "*",
-				"npm-pick-manifest": "*",
-				"npm-profile": "*",
-				"npm-registry-fetch": "*",
-				"npm-user-validate": "*",
-				"npmlog": "*",
-				"opener": "*",
-				"pacote": "*",
-				"parse-conflict-json": "*",
-				"proc-log": "*",
-				"qrcode-terminal": "*",
-				"read": "*",
-				"read-package-json": "*",
-				"read-package-json-fast": "*",
-				"readdir-scoped-modules": "*",
-				"rimraf": "*",
-				"semver": "*",
-				"ssri": "*",
-				"tar": "*",
-				"text-table": "*",
-				"tiny-relative-date": "*",
-				"treeverse": "*",
-				"validate-npm-package-name": "*",
-				"which": "*",
-				"write-file-atomic": "*"
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^5.0.3",
+				"@npmcli/ci-detect": "^2.0.0",
+				"@npmcli/config": "^4.0.1",
+				"@npmcli/map-workspaces": "^2.0.2",
+				"@npmcli/package-json": "^1.0.1",
+				"@npmcli/run-script": "^3.0.1",
+				"abbrev": "~1.1.1",
+				"ansicolors": "~0.3.2",
+				"ansistyles": "~0.1.3",
+				"archy": "~1.0.0",
+				"cacache": "^16.0.2",
+				"chalk": "^4.1.2",
+				"chownr": "^2.0.0",
+				"cli-columns": "^4.0.0",
+				"cli-table3": "^0.6.1",
+				"columnify": "^1.6.0",
+				"fastest-levenshtein": "^1.0.12",
+				"glob": "^7.2.0",
+				"graceful-fs": "^4.2.9",
+				"hosted-git-info": "^5.0.0",
+				"ini": "^2.0.0",
+				"init-package-json": "^3.0.1",
+				"is-cidr": "^4.0.2",
+				"json-parse-even-better-errors": "^2.3.1",
+				"libnpmaccess": "^6.0.2",
+				"libnpmdiff": "^4.0.2",
+				"libnpmexec": "^4.0.2",
+				"libnpmfund": "^3.0.1",
+				"libnpmhook": "^8.0.2",
+				"libnpmorg": "^4.0.2",
+				"libnpmpack": "^4.0.2",
+				"libnpmpublish": "^6.0.2",
+				"libnpmsearch": "^5.0.2",
+				"libnpmteam": "^4.0.2",
+				"libnpmversion": "^3.0.1",
+				"make-fetch-happen": "^10.0.6",
+				"minipass": "^3.1.6",
+				"minipass-pipeline": "^1.2.4",
+				"mkdirp": "^1.0.4",
+				"mkdirp-infer-owner": "^2.0.0",
+				"ms": "^2.1.2",
+				"node-gyp": "^9.0.0",
+				"nopt": "^5.0.0",
+				"npm-audit-report": "^2.1.5",
+				"npm-install-checks": "^4.0.0",
+				"npm-package-arg": "^9.0.1",
+				"npm-pick-manifest": "^7.0.0",
+				"npm-profile": "^6.0.2",
+				"npm-registry-fetch": "^13.0.1",
+				"npm-user-validate": "^1.0.1",
+				"npmlog": "^6.0.1",
+				"opener": "^1.5.2",
+				"pacote": "^13.0.5",
+				"parse-conflict-json": "^2.0.1",
+				"proc-log": "^2.0.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "~1.0.7",
+				"read-package-json": "^5.0.0",
+				"read-package-json-fast": "^2.0.3",
+				"readdir-scoped-modules": "^1.1.0",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"ssri": "^8.0.1",
+				"tar": "^6.1.11",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^1.0.4",
+				"validate-npm-package-name": "~3.0.0",
+				"which": "^2.0.2",
+				"write-file-atomic": "^4.0.1"
 			},
 			"dependencies": {
 				"@gar/promisify": {
@@ -6956,20 +6891,20 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.0.2",
+					"version": "5.0.3",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/map-workspaces": "^2.0.0",
-						"@npmcli/metavuln-calculator": "^3.0.0",
+						"@npmcli/metavuln-calculator": "^3.0.1",
 						"@npmcli/move-file": "^1.1.0",
 						"@npmcli/name-from-folder": "^1.0.1",
 						"@npmcli/node-gyp": "^1.0.3",
 						"@npmcli/package-json": "^1.0.1",
 						"@npmcli/run-script": "^3.0.0",
 						"bin-links": "^3.0.0",
-						"cacache": "^15.0.3",
+						"cacache": "^16.0.0",
 						"common-ancestor-path": "^1.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"json-stringify-nice": "^1.1.4",
@@ -6981,7 +6916,7 @@
 						"npm-pick-manifest": "^7.0.0",
 						"npm-registry-fetch": "^13.0.0",
 						"npmlog": "^6.0.1",
-						"pacote": "^13.0.2",
+						"pacote": "^13.0.5",
 						"parse-conflict-json": "^2.0.1",
 						"proc-log": "^2.0.0",
 						"promise-all-reject-late": "^1.0.0",
@@ -7041,12 +6976,6 @@
 						"promise-retry": "^2.0.1",
 						"semver": "^7.3.5",
 						"which": "^2.0.2"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "7.4.0",
-							"bundled": true
-						}
 					}
 				},
 				"@npmcli/installed-package-contents": {
@@ -7084,12 +7013,12 @@
 					}
 				},
 				"@npmcli/metavuln-calculator": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"cacache": "^15.3.0",
+						"cacache": "^16.0.0",
 						"json-parse-even-better-errors": "^2.3.1",
-						"pacote": "^13.0.1",
+						"pacote": "^13.0.3",
 						"semver": "^7.3.5"
 					}
 				},
@@ -7165,6 +7094,10 @@
 						"indent-string": "^4.0.0"
 					}
 				},
+				"ansi-regex": {
+					"version": "5.0.1",
+					"bundled": true
+				},
 				"ansi-styles": {
 					"version": "4.3.0",
 					"bundled": true,
@@ -7233,26 +7166,26 @@
 					"bundled": true
 				},
 				"cacache": {
-					"version": "15.3.0",
+					"version": "16.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/fs": "^1.0.0",
-						"@npmcli/move-file": "^1.0.1",
+						"@npmcli/move-file": "^1.1.2",
 						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"glob": "^7.1.4",
+						"fs-minipass": "^2.1.0",
+						"glob": "^7.2.0",
 						"infer-owner": "^1.0.4",
-						"lru-cache": "^6.0.0",
-						"minipass": "^3.1.1",
+						"lru-cache": "^7.5.1",
+						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
 						"minipass-flush": "^1.0.5",
-						"minipass-pipeline": "^1.2.2",
-						"mkdirp": "^1.0.3",
+						"minipass-pipeline": "^1.2.4",
+						"mkdirp": "^1.0.4",
 						"p-map": "^4.0.0",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^3.0.2",
 						"ssri": "^8.0.1",
-						"tar": "^6.0.2",
+						"tar": "^6.1.11",
 						"unique-filename": "^1.1.1"
 					}
 				},
@@ -7285,19 +7218,6 @@
 					"requires": {
 						"string-width": "^4.2.3",
 						"strip-ansi": "^6.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.1",
-							"bundled": true
-						},
-						"strip-ansi": {
-							"version": "6.0.1",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^5.0.1"
-							}
-						}
 					}
 				},
 				"cli-table3": {
@@ -7345,19 +7265,6 @@
 					"requires": {
 						"strip-ansi": "^6.0.1",
 						"wcwidth": "^1.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.1",
-							"bundled": true
-						},
-						"strip-ansi": {
-							"version": "6.0.1",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^5.0.1"
-							}
-						}
 					}
 				},
 				"common-ancestor-path": {
@@ -7467,19 +7374,6 @@
 						"string-width": "^4.2.3",
 						"strip-ansi": "^6.0.1",
 						"wide-align": "^1.1.5"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.1",
-							"bundled": true
-						},
-						"strip-ansi": {
-							"version": "6.0.1",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^5.0.1"
-							}
-						}
 					}
 				},
 				"glob": {
@@ -7514,10 +7408,10 @@
 					"bundled": true
 				},
 				"hosted-git-info": {
-					"version": "4.1.0",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.5.1"
 					}
 				},
 				"http-cache-semantics": {
@@ -7592,13 +7486,13 @@
 					"bundled": true
 				},
 				"init-package-json": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
 						"npm-package-arg": "^9.0.0",
 						"promzard": "^0.3.0",
 						"read": "^1.0.7",
-						"read-package-json": "^4.1.1",
+						"read-package-json": "^5.0.0",
 						"semver": "^7.3.5",
 						"validate-npm-package-license": "^3.0.4",
 						"validate-npm-package-name": "^3.0.0"
@@ -7659,17 +7553,17 @@
 					"bundled": true
 				},
 				"libnpmaccess": {
-					"version": "6.0.1",
+					"version": "6.0.2",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
 						"minipass": "^3.1.1",
-						"npm-package-arg": "^9.0.0",
+						"npm-package-arg": "^9.0.1",
 						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmdiff": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/disparity-colors": "^1.0.1",
@@ -7677,13 +7571,13 @@
 						"binary-extensions": "^2.2.0",
 						"diff": "^5.0.0",
 						"minimatch": "^3.0.4",
-						"npm-package-arg": "^9.0.0",
-						"pacote": "^13.0.2",
+						"npm-package-arg": "^9.0.1",
+						"pacote": "^13.0.5",
 						"tar": "^6.1.0"
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0",
@@ -7691,9 +7585,9 @@
 						"@npmcli/run-script": "^3.0.0",
 						"chalk": "^4.1.0",
 						"mkdirp-infer-owner": "^2.0.0",
-						"npm-package-arg": "^9.0.0",
+						"npm-package-arg": "^9.0.1",
 						"npmlog": "^6.0.1",
-						"pacote": "^13.0.2",
+						"pacote": "^13.0.5",
 						"proc-log": "^2.0.0",
 						"read": "^1.0.7",
 						"read-package-json-fast": "^2.0.2",
@@ -7708,7 +7602,7 @@
 					}
 				},
 				"libnpmhook": {
-					"version": "8.0.1",
+					"version": "8.0.2",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7716,7 +7610,7 @@
 					}
 				},
 				"libnpmorg": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7724,34 +7618,34 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/run-script": "^3.0.0",
-						"npm-package-arg": "^9.0.0",
-						"pacote": "^13.0.2"
+						"npm-package-arg": "^9.0.1",
+						"pacote": "^13.0.5"
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.1",
+					"version": "6.0.2",
 					"bundled": true,
 					"requires": {
-						"normalize-package-data": "^3.0.2",
-						"npm-package-arg": "^9.0.0",
+						"normalize-package-data": "^4.0.0",
+						"npm-package-arg": "^9.0.1",
 						"npm-registry-fetch": "^13.0.0",
 						"semver": "^7.1.3",
 						"ssri": "^8.0.1"
 					}
 				},
 				"libnpmsearch": {
-					"version": "5.0.1",
+					"version": "5.0.2",
 					"bundled": true,
 					"requires": {
 						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmteam": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7771,38 +7665,29 @@
 					}
 				},
 				"lru-cache": {
-					"version": "6.0.0",
-					"bundled": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
+					"version": "7.5.1",
+					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.0.5",
+					"version": "10.0.6",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
-						"cacache": "^15.3.0",
+						"cacache": "^16.0.0",
 						"http-cache-semantics": "^4.1.0",
 						"http-proxy-agent": "^5.0.0",
 						"https-proxy-agent": "^5.0.0",
 						"is-lambda": "^1.0.1",
-						"lru-cache": "^7.4.1",
+						"lru-cache": "^7.5.1",
 						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
-						"minipass-fetch": "^2.0.2",
+						"minipass-fetch": "^2.0.3",
 						"minipass-flush": "^1.0.5",
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.3",
 						"promise-retry": "^2.0.1",
 						"socks-proxy-agent": "^6.1.1",
 						"ssri": "^8.0.1"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "7.4.2",
-							"bundled": true
-						}
 					}
 				},
 				"minimatch": {
@@ -7827,7 +7712,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "2.0.2",
+					"version": "2.0.3",
 					"bundled": true,
 					"requires": {
 						"encoding": "^0.1.13",
@@ -7922,13 +7807,13 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.3",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
+						"hosted-git-info": "^5.0.0",
+						"is-core-module": "^2.8.1",
+						"semver": "^7.3.5",
+						"validate-npm-package-license": "^3.0.4"
 					}
 				},
 				"npm-audit-report": {
@@ -7957,21 +7842,21 @@
 					"bundled": true
 				},
 				"npm-package-arg": {
-					"version": "9.0.0",
+					"version": "9.0.1",
 					"bundled": true,
 					"requires": {
-						"hosted-git-info": "^4.1.0",
+						"hosted-git-info": "^5.0.0",
 						"semver": "^7.3.5",
 						"validate-npm-package-name": "^3.0.0"
 					}
 				},
 				"npm-packlist": {
-					"version": "3.0.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.1.6",
+						"glob": "^7.2.0",
 						"ignore-walk": "^4.0.1",
-						"npm-bundled": "^1.1.1",
+						"npm-bundled": "^1.1.2",
 						"npm-normalize-package-bin": "^1.0.1"
 					}
 				},
@@ -8039,26 +7924,26 @@
 					}
 				},
 				"pacote": {
-					"version": "13.0.3",
+					"version": "13.0.5",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/promise-spawn": "^1.2.0",
-						"@npmcli/run-script": "^3.0.0",
-						"cacache": "^15.3.0",
+						"@npmcli/run-script": "^3.0.1",
+						"cacache": "^16.0.0",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
 						"infer-owner": "^1.0.4",
 						"minipass": "^3.1.6",
 						"mkdirp": "^1.0.4",
 						"npm-package-arg": "^9.0.0",
-						"npm-packlist": "^3.0.0",
+						"npm-packlist": "^4.0.0",
 						"npm-pick-manifest": "^7.0.0",
-						"npm-registry-fetch": "^13.0.0",
+						"npm-registry-fetch": "^13.0.1",
 						"proc-log": "^2.0.0",
 						"promise-retry": "^2.0.1",
-						"read-package-json": "^4.1.1",
+						"read-package-json": "^5.0.0",
 						"read-package-json-fast": "^2.0.3",
 						"rimraf": "^3.0.2",
 						"ssri": "^8.0.1",
@@ -8125,13 +8010,13 @@
 					"bundled": true
 				},
 				"read-package-json": {
-					"version": "4.1.2",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"normalize-package-data": "^3.0.0",
-						"npm-normalize-package-bin": "^1.0.0"
+						"glob": "^7.2.0",
+						"json-parse-even-better-errors": "^2.3.1",
+						"normalize-package-data": "^4.0.0",
+						"npm-normalize-package-bin": "^1.0.1"
 					}
 				},
 				"read-package-json-fast": {
@@ -8186,6 +8071,15 @@
 					"bundled": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
 					}
 				},
 				"set-blocking": {
@@ -8262,24 +8156,18 @@
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "5.0.1",
-							"bundled": true
-						},
-						"strip-ansi": {
-							"version": "6.0.1",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^5.0.1"
-							}
-						}
 					}
 				},
 				"stringify-package": {
 					"version": "1.0.1",
 					"bundled": true
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
 				},
 				"supports-color": {
 					"version": "7.2.0",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._