### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -327,9 +327,9 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.2.tgz",
-			"integrity": "sha512-wIbfhOeuxlYzMTjtSAa2xgr54n7ZuPAS2gadyTWBpUt2PNAPgla7A6XxCXJnaKPgfVF0iFfSk3B+KlVKk6ByVg==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+			"integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
 			"dependencies": {
 				"@octokit/rest": "^18.0.0",
 				"@semantic-release/error": "^2.2.0",
@@ -5610,9 +5610,9 @@
 			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
 		},
 		"@semantic-release/github": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.2.tgz",
-			"integrity": "sha512-wIbfhOeuxlYzMTjtSAa2xgr54n7ZuPAS2gadyTWBpUt2PNAPgla7A6XxCXJnaKPgfVF0iFfSk3B+KlVKk6ByVg==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
+			"integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
 			"requires": {
 				"@octokit/rest": "^18.0.0",
 				"@semantic-release/error": "^2.2.0",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._