### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,14 +35,14 @@
 			}
 		},
 		"node_modules/@actions/github": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-			"integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
+			"integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
 			"dependencies": {
 				"@actions/http-client": "^1.0.11",
-				"@octokit/core": "^3.4.0",
-				"@octokit/plugin-paginate-rest": "^2.13.3",
-				"@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+				"@octokit/core": "^3.6.0",
+				"@octokit/plugin-paginate-rest": "^2.17.0",
+				"@octokit/plugin-rest-endpoint-methods": "^5.13.0"
 			}
 		},
 		"node_modules/@actions/http-client": {
@@ -1954,14 +1954,15 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.5.5",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
-			"integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+			"integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
 				"@npmcli/ci-detect",
 				"@npmcli/config",
+				"@npmcli/fs",
 				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
 				"@npmcli/run-script",
@@ -2032,9 +2033,10 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.3",
+				"@npmcli/arborist": "^5.0.4",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.0.1",
+				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.2",
 				"@npmcli/package-json": "^1.0.1",
 				"@npmcli/run-script": "^3.0.1",
@@ -2042,7 +2044,7 @@
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.2",
+				"cacache": "^16.0.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -2053,7 +2055,7 @@
 				"graceful-fs": "^4.2.9",
 				"hosted-git-info": "^5.0.0",
 				"ini": "^2.0.0",
-				"init-package-json": "^3.0.1",
+				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.2",
@@ -2067,7 +2069,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.0.6",
+				"make-fetch-happen": "^10.1.1",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -2075,18 +2077,18 @@
 				"ms": "^2.1.2",
 				"node-gyp": "^9.0.0",
 				"nopt": "^5.0.0",
-				"npm-audit-report": "^2.1.5",
+				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^4.0.0",
 				"npm-package-arg": "^9.0.1",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-profile": "^6.0.2",
-				"npm-registry-fetch": "^13.0.1",
+				"npm-registry-fetch": "^13.1.0",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.1",
 				"opener": "^1.5.2",
 				"pacote": "^13.0.5",
-				"parse-conflict-json": "^2.0.1",
-				"proc-log": "^2.0.0",
+				"parse-conflict-json": "^2.0.2",
+				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
 				"read-package-json": "^5.0.0",
@@ -2099,7 +2101,7 @@
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"treeverse": "^1.0.4",
-				"validate-npm-package-name": "~3.0.0",
+				"validate-npm-package-name": "^4.0.0",
 				"which": "^2.0.2",
 				"write-file-atomic": "^4.0.1"
 			},
@@ -2133,7 +2135,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.0.3",
+			"version": "5.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2176,7 +2178,7 @@
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/ci-detect": {
@@ -2217,15 +2219,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "1.1.0",
+			"version": "2.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@gar/promisify": "^1.0.1",
+				"@gar/promisify": "^1.1.3",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
@@ -2508,22 +2510,25 @@
 			}
 		},
 		"node_modules/npm/node_modules/builtins": {
-			"version": "1.0.3",
+			"version": "5.0.0",
 			"inBundle": true,
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.0.0"
+			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.0.2",
+			"version": "16.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^1.0.0",
+				"@npmcli/fs": "^2.1.0",
 				"@npmcli/move-file": "^1.1.2",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
 				"glob": "^7.2.0",
 				"infer-owner": "^1.0.4",
-				"lru-cache": "^7.5.1",
+				"lru-cache": "^7.7.1",
 				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
 				"minipass-flush": "^1.0.5",
@@ -2537,7 +2542,7 @@
 				"unique-filename": "^1.1.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
@@ -2688,7 +2693,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/debug": {
-			"version": "4.3.3",
+			"version": "4.3.4",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2808,7 +2813,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/gauge": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2822,7 +2827,7 @@
 				"wide-align": "^1.1.5"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
@@ -2989,20 +2994,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^9.0.0",
+				"npm-package-arg": "^9.0.1",
 				"promzard": "^0.3.0",
 				"read": "^1.0.7",
 				"read-package-json": "^5.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^3.0.0"
+				"validate-npm-package-name": "^4.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/ip": {
@@ -3085,7 +3090,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff-apply": {
-			"version": "4.0.1",
+			"version": "5.2.0",
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3100,7 +3105,7 @@
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
@@ -3118,7 +3123,7 @@
 				"tar": "^6.1.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
@@ -3140,7 +3145,7 @@
 				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
@@ -3151,7 +3156,7 @@
 				"@npmcli/arborist": "^5.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
@@ -3163,7 +3168,7 @@
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
@@ -3175,7 +3180,7 @@
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
@@ -3188,7 +3193,7 @@
 				"pacote": "^13.0.5"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
@@ -3203,7 +3208,7 @@
 				"ssri": "^8.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
@@ -3214,7 +3219,7 @@
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
@@ -3226,7 +3231,7 @@
 				"npm-registry-fetch": "^13.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
@@ -3242,11 +3247,11 @@
 				"stringify-package": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "7.5.1",
+			"version": "7.7.1",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3254,17 +3259,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.0.6",
+			"version": "10.1.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.2.1",
-				"cacache": "^16.0.0",
+				"cacache": "^16.0.2",
 				"http-cache-semantics": "^4.1.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
 				"is-lambda": "^1.0.1",
-				"lru-cache": "^7.5.1",
+				"lru-cache": "^7.7.1",
 				"minipass": "^3.1.6",
 				"minipass-collect": "^1.0.2",
 				"minipass-fetch": "^2.0.3",
@@ -3276,7 +3281,7 @@
 				"ssri": "^8.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
@@ -3313,7 +3318,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "2.0.3",
+			"version": "2.1.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3322,7 +3327,7 @@
 				"minizlib": "^2.1.2"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
@@ -3476,14 +3481,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
-			"version": "2.1.5",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"chalk": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
@@ -3511,16 +3516,16 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "9.0.1",
+			"version": "9.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"hosted-git-info": "^5.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^3.0.0"
+				"validate-npm-package-name": "^4.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
@@ -3567,20 +3572,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "13.0.1",
+			"version": "13.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"make-fetch-happen": "^10.0.3",
+				"make-fetch-happen": "^10.0.6",
 				"minipass": "^3.1.6",
-				"minipass-fetch": "^2.0.1",
+				"minipass-fetch": "^2.0.3",
 				"minipass-json-stream": "^1.0.1",
 				"minizlib": "^2.1.2",
-				"npm-package-arg": "^9.0.0",
+				"npm-package-arg": "^9.0.1",
 				"proc-log": "^2.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
@@ -3667,16 +3672,16 @@
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"json-parse-even-better-errors": "^2.3.1",
 				"just-diff": "^5.0.1",
-				"just-diff-apply": "^4.0.1"
+				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/path-is-absolute": {
@@ -3688,11 +3693,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -4075,11 +4080,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "3.0.0",
+			"version": "4.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"builtins": "^1.0.3"
+				"builtins": "^5.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
@@ -5363,14 +5371,14 @@
 			}
 		},
 		"@actions/github": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-			"integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
+			"integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
 			"requires": {
 				"@actions/http-client": "^1.0.11",
-				"@octokit/core": "^3.4.0",
-				"@octokit/plugin-paginate-rest": "^2.13.3",
-				"@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+				"@octokit/core": "^3.6.0",
+				"@octokit/plugin-paginate-rest": "^2.17.0",
+				"@octokit/plugin-rest-endpoint-methods": "^5.13.0"
 			}
 		},
 		"@actions/http-client": {
@@ -6805,14 +6813,15 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.5.5",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.5.5.tgz",
-			"integrity": "sha512-a1vl26nokCNlD+my/iNYmOUPx/hpYR4ZyZk8gb7/A2XXtrPZf2gTSJOnVjS77jQS+BSfIVQpipZwXWCL0+5wzg==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
+			"integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.3",
+				"@npmcli/arborist": "^5.0.4",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.0.1",
+				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.2",
 				"@npmcli/package-json": "^1.0.1",
 				"@npmcli/run-script": "^3.0.1",
@@ -6820,7 +6829,7 @@
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.2",
+				"cacache": "^16.0.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -6831,7 +6840,7 @@
 				"graceful-fs": "^4.2.9",
 				"hosted-git-info": "^5.0.0",
 				"ini": "^2.0.0",
-				"init-package-json": "^3.0.1",
+				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.2",
@@ -6845,7 +6854,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.0.6",
+				"make-fetch-happen": "^10.1.1",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -6853,18 +6862,18 @@
 				"ms": "^2.1.2",
 				"node-gyp": "^9.0.0",
 				"nopt": "^5.0.0",
-				"npm-audit-report": "^2.1.5",
+				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^4.0.0",
 				"npm-package-arg": "^9.0.1",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-profile": "^6.0.2",
-				"npm-registry-fetch": "^13.0.1",
+				"npm-registry-fetch": "^13.1.0",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.1",
 				"opener": "^1.5.2",
 				"pacote": "^13.0.5",
-				"parse-conflict-json": "^2.0.1",
-				"proc-log": "^2.0.0",
+				"parse-conflict-json": "^2.0.2",
+				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
 				"read-package-json": "^5.0.0",
@@ -6877,7 +6886,7 @@
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"treeverse": "^1.0.4",
-				"validate-npm-package-name": "~3.0.0",
+				"validate-npm-package-name": "^4.0.0",
 				"which": "^2.0.2",
 				"write-file-atomic": "^4.0.1"
 			},
@@ -6891,7 +6900,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.0.3",
+					"version": "5.0.4",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -6956,10 +6965,10 @@
 					}
 				},
 				"@npmcli/fs": {
-					"version": "1.1.0",
+					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
-						"@gar/promisify": "^1.0.1",
+						"@gar/promisify": "^1.1.3",
 						"semver": "^7.3.5"
 					}
 				},
@@ -7162,20 +7171,23 @@
 					}
 				},
 				"builtins": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"cacache": {
-					"version": "16.0.2",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/fs": "^1.0.0",
+						"semver": "^7.0.0"
+					}
+				},
+				"cacache": {
+					"version": "16.0.3",
+					"bundled": true,
+					"requires": {
+						"@npmcli/fs": "^2.1.0",
 						"@npmcli/move-file": "^1.1.2",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
 						"glob": "^7.2.0",
 						"infer-owner": "^1.0.4",
-						"lru-cache": "^7.5.1",
+						"lru-cache": "^7.7.1",
 						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
 						"minipass-flush": "^1.0.5",
@@ -7280,7 +7292,7 @@
 					"bundled": true
 				},
 				"debug": {
-					"version": "4.3.3",
+					"version": "4.3.4",
 					"bundled": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -7363,7 +7375,7 @@
 					"bundled": true
 				},
 				"gauge": {
-					"version": "4.0.3",
+					"version": "4.0.4",
 					"bundled": true,
 					"requires": {
 						"aproba": "^1.0.3 || ^2.0.0",
@@ -7486,16 +7498,16 @@
 					"bundled": true
 				},
 				"init-package-json": {
-					"version": "3.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"npm-package-arg": "^9.0.0",
+						"npm-package-arg": "^9.0.1",
 						"promzard": "^0.3.0",
 						"read": "^1.0.7",
 						"read-package-json": "^5.0.0",
 						"semver": "^7.3.5",
 						"validate-npm-package-license": "^3.0.4",
-						"validate-npm-package-name": "^3.0.0"
+						"validate-npm-package-name": "^4.0.0"
 					}
 				},
 				"ip": {
@@ -7549,7 +7561,7 @@
 					"bundled": true
 				},
 				"just-diff-apply": {
-					"version": "4.0.1",
+					"version": "5.2.0",
 					"bundled": true
 				},
 				"libnpmaccess": {
@@ -7665,20 +7677,20 @@
 					}
 				},
 				"lru-cache": {
-					"version": "7.5.1",
+					"version": "7.7.1",
 					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.0.6",
+					"version": "10.1.1",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
-						"cacache": "^16.0.0",
+						"cacache": "^16.0.2",
 						"http-cache-semantics": "^4.1.0",
 						"http-proxy-agent": "^5.0.0",
 						"https-proxy-agent": "^5.0.0",
 						"is-lambda": "^1.0.1",
-						"lru-cache": "^7.5.1",
+						"lru-cache": "^7.7.1",
 						"minipass": "^3.1.6",
 						"minipass-collect": "^1.0.2",
 						"minipass-fetch": "^2.0.3",
@@ -7712,7 +7724,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "2.0.3",
+					"version": "2.1.0",
 					"bundled": true,
 					"requires": {
 						"encoding": "^0.1.13",
@@ -7817,7 +7829,7 @@
 					}
 				},
 				"npm-audit-report": {
-					"version": "2.1.5",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
 						"chalk": "^4.0.0"
@@ -7842,12 +7854,12 @@
 					"bundled": true
 				},
 				"npm-package-arg": {
-					"version": "9.0.1",
+					"version": "9.0.2",
 					"bundled": true,
 					"requires": {
 						"hosted-git-info": "^5.0.0",
 						"semver": "^7.3.5",
-						"validate-npm-package-name": "^3.0.0"
+						"validate-npm-package-name": "^4.0.0"
 					}
 				},
 				"npm-packlist": {
@@ -7879,15 +7891,15 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "13.0.1",
+					"version": "13.1.0",
 					"bundled": true,
 					"requires": {
-						"make-fetch-happen": "^10.0.3",
+						"make-fetch-happen": "^10.0.6",
 						"minipass": "^3.1.6",
-						"minipass-fetch": "^2.0.1",
+						"minipass-fetch": "^2.0.3",
 						"minipass-json-stream": "^1.0.1",
 						"minizlib": "^2.1.2",
-						"npm-package-arg": "^9.0.0",
+						"npm-package-arg": "^9.0.1",
 						"proc-log": "^2.0.0"
 					}
 				},
@@ -7951,12 +7963,12 @@
 					}
 				},
 				"parse-conflict-json": {
-					"version": "2.0.1",
+					"version": "2.0.2",
 					"bundled": true,
 					"requires": {
 						"json-parse-even-better-errors": "^2.3.1",
 						"just-diff": "^5.0.1",
-						"just-diff-apply": "^4.0.1"
+						"just-diff-apply": "^5.2.0"
 					}
 				},
 				"path-is-absolute": {
@@ -7964,7 +7976,7 @@
 					"bundled": true
 				},
 				"proc-log": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true
 				},
 				"promise-all-reject-late": {
@@ -8227,10 +8239,10 @@
 					}
 				},
 				"validate-npm-package-name": {
-					"version": "3.0.0",
+					"version": "4.0.0",
 					"bundled": true,
 					"requires": {
-						"builtins": "^1.0.3"
+						"builtins": "^5.0.0"
 					}
 				},
 				"walk-up-path": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._