### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,9 +78,9 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -1238,9 +1238,9 @@
 			}
 		},
 		"node_modules/graceful-fs": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.7",
@@ -4719,17 +4719,17 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/semver-diff": {
@@ -4760,6 +4760,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semver/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -5408,9 +5416,9 @@
 			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
 		},
 		"@babel/highlight": {
-			"version": "7.16.10",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
-			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -6298,9 +6306,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
 		},
 		"handlebars": {
 			"version": "4.7.7",
@@ -8691,11 +8699,18 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"requires": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				}
 			}
 		},
 		"semver-diff": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._