### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1733,9 +1733,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-			"integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -4763,9 +4763,9 @@
 			}
 		},
 		"node_modules/semver/node_modules/lru-cache": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -5198,9 +5198,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+			"version": "3.15.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -6669,9 +6669,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-			"integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+			"version": "4.0.14",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
+			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -8707,9 +8707,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+					"version": "7.8.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
 				}
 			}
 		},
@@ -9060,9 +9060,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
-			"integrity": "sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==",
+			"version": "3.15.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._