### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -423,9 +432,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.24",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+			"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -632,9 +641,9 @@
 			}
 		},
 		"node_modules/cli-table3": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-			"integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
 			"dependencies": {
 				"string-width": "^4.2.0"
 			},
@@ -642,7 +651,7 @@
 				"node": "10.* || >= 12.*"
 			},
 			"optionalDependencies": {
-				"colors": "1.4.0"
+				"@colors/colors": "1.5.0"
 			}
 		},
 		"node_modules/cliui": {
@@ -670,15 +679,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"node_modules/colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"optional": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
 		},
 		"node_modules/compare-func": {
 			"version": "2.0.0",
@@ -1117,9 +1117,9 @@
 			]
 		},
 		"node_modules/fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -1322,9 +1322,9 @@
 			}
 		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
-			"integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
+			"integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -1967,8 +1967,6 @@
 				"@npmcli/package-json",
 				"@npmcli/run-script",
 				"abbrev",
-				"ansicolors",
-				"ansistyles",
 				"archy",
 				"cacache",
 				"chalk",
@@ -2035,16 +2033,14 @@
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/arborist": "^5.0.4",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/config": "^4.0.1",
+				"@npmcli/config": "^4.1.0",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.2",
-				"@npmcli/package-json": "^1.0.1",
+				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.3",
+				"cacache": "^16.0.4",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -2052,9 +2048,9 @@
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
 				"glob": "^7.2.0",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.10",
 				"hosted-git-info": "^5.0.0",
-				"ini": "^2.0.0",
+				"ini": "^3.0.0",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
@@ -2069,7 +2065,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.1",
+				"make-fetch-happen": "^10.1.2",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -2078,15 +2074,15 @@
 				"node-gyp": "^9.0.0",
 				"nopt": "^5.0.0",
 				"npm-audit-report": "^3.0.0",
-				"npm-install-checks": "^4.0.0",
-				"npm-package-arg": "^9.0.1",
-				"npm-pick-manifest": "^7.0.0",
+				"npm-install-checks": "^5.0.0",
+				"npm-package-arg": "^9.0.2",
+				"npm-pick-manifest": "^7.0.1",
 				"npm-profile": "^6.0.2",
 				"npm-registry-fetch": "^13.1.0",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.1",
 				"opener": "^1.5.2",
-				"pacote": "^13.0.5",
+				"pacote": "^13.1.1",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
@@ -2095,12 +2091,12 @@
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"ssri": "^8.0.1",
+				"semver": "^7.3.6",
+				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
-				"treeverse": "^1.0.4",
+				"treeverse": "^2.0.0",
 				"validate-npm-package-name": "^4.0.0",
 				"which": "^2.0.2",
 				"write-file-atomic": "^4.0.1"
@@ -2135,7 +2131,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.0.4",
+			"version": "5.0.6",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2143,10 +2139,10 @@
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/map-workspaces": "^2.0.0",
 				"@npmcli/metavuln-calculator": "^3.0.1",
-				"@npmcli/move-file": "^1.1.0",
+				"@npmcli/move-file": "^2.0.0",
 				"@npmcli/name-from-folder": "^1.0.1",
-				"@npmcli/node-gyp": "^1.0.3",
-				"@npmcli/package-json": "^1.0.1",
+				"@npmcli/node-gyp": "^2.0.0",
+				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.0",
 				"bin-links": "^3.0.0",
 				"cacache": "^16.0.0",
@@ -2156,7 +2152,7 @@
 				"mkdirp": "^1.0.4",
 				"mkdirp-infer-owner": "^2.0.0",
 				"nopt": "^5.0.0",
-				"npm-install-checks": "^4.0.0",
+				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.0.0",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-registry-fetch": "^13.0.0",
@@ -2170,8 +2166,8 @@
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
-				"ssri": "^8.0.1",
-				"treeverse": "^1.0.4",
+				"ssri": "^9.0.0",
+				"treeverse": "^2.0.0",
 				"walk-up-path": "^1.0.0"
 			},
 			"bin": {
@@ -2190,12 +2186,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "4.0.1",
+			"version": "4.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^2.0.1",
-				"ini": "^2.0.0",
+				"@npmcli/map-workspaces": "^2.0.2",
+				"ini": "^3.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"nopt": "^5.0.0",
 				"proc-log": "^2.0.0",
@@ -2204,18 +2200,18 @@
 				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/disparity-colors": {
-			"version": "1.0.1",
+			"version": "2.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"ansi-styles": "^4.3.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
@@ -2231,12 +2227,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^1.3.2",
-				"lru-cache": "^7.3.1",
+				"@npmcli/promise-spawn": "^3.0.0",
+				"lru-cache": "^7.4.4",
 				"mkdirp": "^1.0.4",
 				"npm-pick-manifest": "^7.0.0",
 				"proc-log": "^2.0.0",
@@ -2246,7 +2242,7 @@
 				"which": "^2.0.2"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
@@ -2278,27 +2274,8 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
-		"node_modules/npm/node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
-			"version": "5.0.1",
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "3.0.1",
+			"version": "3.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2308,11 +2285,11 @@
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/move-file": {
-			"version": "1.1.2",
+			"version": "2.0.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2320,7 +2297,7 @@
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
@@ -2329,38 +2306,47 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/node-gyp": {
-			"version": "1.0.3",
+			"version": "2.0.0",
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "1.0.1",
+			"version": "2.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"json-parse-even-better-errors": "^2.3.1"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "1.3.2",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"infer-owner": "^1.0.4"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^1.0.3",
-				"@npmcli/promise-spawn": "^1.3.2",
+				"@npmcli/node-gyp": "^2.0.0",
+				"@npmcli/promise-spawn": "^3.0.0",
 				"node-gyp": "^9.0.0",
 				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@tootallnate/once": {
@@ -2434,16 +2420,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/npm/node_modules/ansicolors": {
-			"version": "0.3.2",
-			"inBundle": true,
-			"license": "MIT"
-		},
-		"node_modules/npm/node_modules/ansistyles": {
-			"version": "0.1.3",
-			"inBundle": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/aproba": {
 			"version": "2.0.0",
 			"inBundle": true,
@@ -2477,19 +2453,19 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cmd-shim": "^4.0.1",
+				"cmd-shim": "^5.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"npm-normalize-package-bin": "^1.0.0",
-				"read-cmd-shim": "^2.0.0",
+				"read-cmd-shim": "^3.0.0",
 				"rimraf": "^3.0.0",
 				"write-file-atomic": "^4.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/binary-extensions": {
@@ -2501,12 +2477,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "1.1.11",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/builtins": {
@@ -2518,12 +2493,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.0.3",
+			"version": "16.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/fs": "^2.1.0",
-				"@npmcli/move-file": "^1.1.2",
+				"@npmcli/move-file": "^2.0.0",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
 				"glob": "^7.2.0",
@@ -2537,7 +2512,7 @@
 				"p-map": "^4.0.0",
 				"promise-inflight": "^1.0.1",
 				"rimraf": "^3.0.2",
-				"ssri": "^8.0.1",
+				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
 				"unique-filename": "^1.1.1"
 			},
@@ -2622,14 +2597,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/cmd-shim": {
-			"version": "4.1.0",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"mkdirp-infer-owner": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/color-convert": {
@@ -2743,7 +2718,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/dezalgo": {
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2849,8 +2824,28 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/npm/node_modules/glob/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npm/node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/npm/node_modules/graceful-fs": {
-			"version": "4.2.9",
+			"version": "4.2.10",
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -2940,14 +2935,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
-			"version": "4.0.1",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"minimatch": "^3.0.4"
+				"minimatch": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/imurmurhash": {
@@ -2986,11 +2981,11 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
@@ -3095,7 +3090,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "6.0.2",
+			"version": "6.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3109,15 +3104,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/disparity-colors": "^1.0.1",
+				"@npmcli/disparity-colors": "^2.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"binary-extensions": "^2.2.0",
 				"diff": "^5.0.0",
-				"minimatch": "^3.0.4",
+				"minimatch": "^5.0.1",
 				"npm-package-arg": "^9.0.1",
 				"pacote": "^13.0.5",
 				"tar": "^6.1.0"
@@ -3127,7 +3122,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3149,7 +3144,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3160,7 +3155,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "8.0.2",
+			"version": "8.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3172,7 +3167,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3184,7 +3179,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3197,7 +3192,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.2",
+			"version": "6.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3205,14 +3200,14 @@
 				"npm-package-arg": "^9.0.1",
 				"npm-registry-fetch": "^13.0.0",
 				"semver": "^7.1.3",
-				"ssri": "^8.0.1"
+				"ssri": "^9.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "5.0.2",
+			"version": "5.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3223,7 +3218,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "4.0.2",
+			"version": "4.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3235,7 +3230,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "3.0.1",
+			"version": "3.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3243,15 +3238,14 @@
 				"@npmcli/run-script": "^3.0.0",
 				"json-parse-even-better-errors": "^2.3.1",
 				"proc-log": "^2.0.0",
-				"semver": "^7.3.5",
-				"stringify-package": "^1.0.1"
+				"semver": "^7.3.5"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "7.7.1",
+			"version": "7.7.3",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3259,7 +3253,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.1.1",
+			"version": "10.1.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3278,21 +3272,21 @@
 				"negotiator": "^0.6.3",
 				"promise-retry": "^2.0.1",
 				"socks-proxy-agent": "^6.1.1",
-				"ssri": "^8.0.1"
+				"ssri": "^9.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "3.1.2",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/minipass": {
@@ -3500,14 +3494,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
@@ -3529,12 +3523,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.2.0",
-				"ignore-walk": "^4.0.1",
+				"ignore-walk": "^5.0.1",
 				"npm-bundled": "^1.1.2",
 				"npm-normalize-package-bin": "^1.0.1"
 			},
@@ -3542,21 +3536,21 @@
 				"npm-packlist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "7.0.0",
+			"version": "7.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-install-checks": "^4.0.0",
+				"npm-install-checks": "^5.0.0",
 				"npm-normalize-package-bin": "^1.0.1",
 				"npm-package-arg": "^9.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
@@ -3638,13 +3632,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.0.5",
+			"version": "13.1.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/git": "^3.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
-				"@npmcli/promise-spawn": "^1.2.0",
+				"@npmcli/promise-spawn": "^3.0.0",
 				"@npmcli/run-script": "^3.0.1",
 				"cacache": "^16.0.0",
 				"chownr": "^2.0.0",
@@ -3653,7 +3647,7 @@
 				"minipass": "^3.1.6",
 				"mkdirp": "^1.0.4",
 				"npm-package-arg": "^9.0.0",
-				"npm-packlist": "^4.0.0",
+				"npm-packlist": "^5.0.0",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-registry-fetch": "^13.0.1",
 				"proc-log": "^2.0.0",
@@ -3661,14 +3655,14 @@
 				"read-package-json": "^5.0.0",
 				"read-package-json-fast": "^2.0.3",
 				"rimraf": "^3.0.2",
-				"ssri": "^8.0.1",
+				"ssri": "^9.0.0",
 				"tar": "^6.1.11"
 			},
 			"bin": {
 				"pacote": "lib/bin.js"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
@@ -3760,9 +3754,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/read-cmd-shim": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
 		},
 		"node_modules/npm/node_modules/read-package-json": {
 			"version": "5.0.0",
@@ -3862,28 +3859,17 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.3.5",
+			"version": "7.3.6",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-			"version": "6.0.0",
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/set-blocking": {
@@ -3960,14 +3946,14 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "8.0.1",
+			"version": "9.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.1.1"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/string_decoder": {
@@ -3990,11 +3976,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/npm/node_modules/stringify-package": {
-			"version": "1.0.1",
-			"inBundle": true,
-			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -4045,9 +4026,12 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/treeverse": {
-			"version": "1.0.4",
+			"version": "2.0.0",
 			"inBundle": true,
-			"license": "ISC"
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
 			"version": "1.1.1",
@@ -4719,17 +4703,17 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.6",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"dependencies": {
-				"lru-cache": "^7.4.0"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/semver-diff": {
@@ -4760,14 +4744,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semver/node_modules/lru-cache": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==",
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -5471,6 +5447,12 @@
 				}
 			}
 		},
+		"@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"optional": true
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5703,9 +5685,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "17.0.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-			"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+			"version": "17.0.24",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+			"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -5858,11 +5840,11 @@
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
 		},
 		"cli-table3": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
-			"integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
+			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
 			"requires": {
-				"colors": "1.4.0",
+				"@colors/colors": "1.5.0",
 				"string-width": "^4.2.0"
 			}
 		},
@@ -5888,12 +5870,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"optional": true
 		},
 		"compare-func": {
 			"version": "2.0.0",
@@ -6210,9 +6186,9 @@
 			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
 		},
 		"fs-extra": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
 			"requires": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -6364,9 +6340,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-			"integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"requires": {
 				"agent-base": "6",
 				"debug": "4"
@@ -6821,23 +6797,21 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.6.0.tgz",
-			"integrity": "sha512-icekvN8FJFESIFkLaFEVl05Nocl5Id5HnoVhJzhCUvtNY8tj9kfUlH/J527fZq/8ltsAUqpettfutwRjQYS2fA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
+			"integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/arborist": "^5.0.4",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/config": "^4.0.1",
+				"@npmcli/config": "^4.1.0",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.2",
-				"@npmcli/package-json": "^1.0.1",
+				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.3",
+				"cacache": "^16.0.4",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -6845,9 +6819,9 @@
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
 				"glob": "^7.2.0",
-				"graceful-fs": "^4.2.9",
+				"graceful-fs": "^4.2.10",
 				"hosted-git-info": "^5.0.0",
-				"ini": "^2.0.0",
+				"ini": "^3.0.0",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
@@ -6862,7 +6836,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.1",
+				"make-fetch-happen": "^10.1.2",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -6871,15 +6845,15 @@
 				"node-gyp": "^9.0.0",
 				"nopt": "^5.0.0",
 				"npm-audit-report": "^3.0.0",
-				"npm-install-checks": "^4.0.0",
-				"npm-package-arg": "^9.0.1",
-				"npm-pick-manifest": "^7.0.0",
+				"npm-install-checks": "^5.0.0",
+				"npm-package-arg": "^9.0.2",
+				"npm-pick-manifest": "^7.0.1",
 				"npm-profile": "^6.0.2",
 				"npm-registry-fetch": "^13.1.0",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.1",
 				"opener": "^1.5.2",
-				"pacote": "^13.0.5",
+				"pacote": "^13.1.1",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
@@ -6888,12 +6862,12 @@
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
-				"ssri": "^8.0.1",
+				"semver": "^7.3.6",
+				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
-				"treeverse": "^1.0.4",
+				"treeverse": "^2.0.0",
 				"validate-npm-package-name": "^4.0.0",
 				"which": "^2.0.2",
 				"write-file-atomic": "^4.0.1"
@@ -6908,17 +6882,17 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.0.4",
+					"version": "5.0.6",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/map-workspaces": "^2.0.0",
 						"@npmcli/metavuln-calculator": "^3.0.1",
-						"@npmcli/move-file": "^1.1.0",
+						"@npmcli/move-file": "^2.0.0",
 						"@npmcli/name-from-folder": "^1.0.1",
-						"@npmcli/node-gyp": "^1.0.3",
-						"@npmcli/package-json": "^1.0.1",
+						"@npmcli/node-gyp": "^2.0.0",
+						"@npmcli/package-json": "^2.0.0",
 						"@npmcli/run-script": "^3.0.0",
 						"bin-links": "^3.0.0",
 						"cacache": "^16.0.0",
@@ -6928,7 +6902,7 @@
 						"mkdirp": "^1.0.4",
 						"mkdirp-infer-owner": "^2.0.0",
 						"nopt": "^5.0.0",
-						"npm-install-checks": "^4.0.0",
+						"npm-install-checks": "^5.0.0",
 						"npm-package-arg": "^9.0.0",
 						"npm-pick-manifest": "^7.0.0",
 						"npm-registry-fetch": "^13.0.0",
@@ -6942,8 +6916,8 @@
 						"readdir-scoped-modules": "^1.1.0",
 						"rimraf": "^3.0.2",
 						"semver": "^7.3.5",
-						"ssri": "^8.0.1",
-						"treeverse": "^1.0.4",
+						"ssri": "^9.0.0",
+						"treeverse": "^2.0.0",
 						"walk-up-path": "^1.0.0"
 					}
 				},
@@ -6952,11 +6926,11 @@
 					"bundled": true
 				},
 				"@npmcli/config": {
-					"version": "4.0.1",
+					"version": "4.1.0",
 					"bundled": true,
 					"requires": {
-						"@npmcli/map-workspaces": "^2.0.1",
-						"ini": "^2.0.0",
+						"@npmcli/map-workspaces": "^2.0.2",
+						"ini": "^3.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"nopt": "^5.0.0",
 						"proc-log": "^2.0.0",
@@ -6966,7 +6940,7 @@
 					}
 				},
 				"@npmcli/disparity-colors": {
-					"version": "1.0.1",
+					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
 						"ansi-styles": "^4.3.0"
@@ -6981,11 +6955,11 @@
 					}
 				},
 				"@npmcli/git": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"@npmcli/promise-spawn": "^1.3.2",
-						"lru-cache": "^7.3.1",
+						"@npmcli/promise-spawn": "^3.0.0",
+						"lru-cache": "^7.4.4",
 						"mkdirp": "^1.0.4",
 						"npm-pick-manifest": "^7.0.0",
 						"proc-log": "^2.0.0",
@@ -7011,26 +6985,10 @@
 						"glob": "^7.2.0",
 						"minimatch": "^5.0.1",
 						"read-package-json-fast": "^2.0.3"
-					},
-					"dependencies": {
-						"brace-expansion": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"balanced-match": "^1.0.0"
-							}
-						},
-						"minimatch": {
-							"version": "5.0.1",
-							"bundled": true,
-							"requires": {
-								"brace-expansion": "^2.0.1"
-							}
-						}
 					}
 				},
 				"@npmcli/metavuln-calculator": {
-					"version": "3.0.1",
+					"version": "3.1.0",
 					"bundled": true,
 					"requires": {
 						"cacache": "^16.0.0",
@@ -7040,7 +6998,7 @@
 					}
 				},
 				"@npmcli/move-file": {
-					"version": "1.1.2",
+					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
 						"mkdirp": "^1.0.4",
@@ -7052,29 +7010,29 @@
 					"bundled": true
 				},
 				"@npmcli/node-gyp": {
-					"version": "1.0.3",
+					"version": "2.0.0",
 					"bundled": true
 				},
 				"@npmcli/package-json": {
-					"version": "1.0.1",
+					"version": "2.0.0",
 					"bundled": true,
 					"requires": {
 						"json-parse-even-better-errors": "^2.3.1"
 					}
 				},
 				"@npmcli/promise-spawn": {
-					"version": "1.3.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
 						"infer-owner": "^1.0.4"
 					}
 				},
 				"@npmcli/run-script": {
-					"version": "3.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
-						"@npmcli/node-gyp": "^1.0.3",
-						"@npmcli/promise-spawn": "^1.3.2",
+						"@npmcli/node-gyp": "^2.0.0",
+						"@npmcli/promise-spawn": "^3.0.0",
 						"node-gyp": "^9.0.0",
 						"read-package-json-fast": "^2.0.3"
 					}
@@ -7122,14 +7080,6 @@
 						"color-convert": "^2.0.1"
 					}
 				},
-				"ansicolors": {
-					"version": "0.3.2",
-					"bundled": true
-				},
-				"ansistyles": {
-					"version": "0.1.3",
-					"bundled": true
-				},
 				"aproba": {
 					"version": "2.0.0",
 					"bundled": true
@@ -7155,13 +7105,13 @@
 					"bundled": true
 				},
 				"bin-links": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
-						"cmd-shim": "^4.0.1",
+						"cmd-shim": "^5.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"npm-normalize-package-bin": "^1.0.0",
-						"read-cmd-shim": "^2.0.0",
+						"read-cmd-shim": "^3.0.0",
 						"rimraf": "^3.0.0",
 						"write-file-atomic": "^4.0.0"
 					}
@@ -7171,11 +7121,10 @@
 					"bundled": true
 				},
 				"brace-expansion": {
-					"version": "1.1.11",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
+						"balanced-match": "^1.0.0"
 					}
 				},
 				"builtins": {
@@ -7186,11 +7135,11 @@
 					}
 				},
 				"cacache": {
-					"version": "16.0.3",
+					"version": "16.0.4",
 					"bundled": true,
 					"requires": {
 						"@npmcli/fs": "^2.1.0",
-						"@npmcli/move-file": "^1.1.2",
+						"@npmcli/move-file": "^2.0.0",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
 						"glob": "^7.2.0",
@@ -7204,7 +7153,7 @@
 						"p-map": "^4.0.0",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
+						"ssri": "^9.0.0",
 						"tar": "^6.1.11",
 						"unique-filename": "^1.1.1"
 					}
@@ -7253,7 +7202,7 @@
 					"bundled": true
 				},
 				"cmd-shim": {
-					"version": "4.1.0",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
 						"mkdirp-infer-owner": "^2.0.0"
@@ -7332,7 +7281,7 @@
 					"bundled": true
 				},
 				"dezalgo": {
-					"version": "1.0.3",
+					"version": "1.0.4",
 					"bundled": true,
 					"requires": {
 						"asap": "^2.0.0",
@@ -7406,10 +7355,27 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					},
+					"dependencies": {
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"minimatch": {
+							"version": "3.1.2",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
 					}
 				},
 				"graceful-fs": {
-					"version": "4.2.9",
+					"version": "4.2.10",
 					"bundled": true
 				},
 				"has": {
@@ -7471,10 +7437,10 @@
 					}
 				},
 				"ignore-walk": {
-					"version": "4.0.1",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "^5.0.1"
 					}
 				},
 				"imurmurhash": {
@@ -7502,7 +7468,7 @@
 					"bundled": true
 				},
 				"ini": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true
 				},
 				"init-package-json": {
@@ -7573,7 +7539,7 @@
 					"bundled": true
 				},
 				"libnpmaccess": {
-					"version": "6.0.2",
+					"version": "6.0.3",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7583,21 +7549,21 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
-						"@npmcli/disparity-colors": "^1.0.1",
+						"@npmcli/disparity-colors": "^2.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"binary-extensions": "^2.2.0",
 						"diff": "^5.0.0",
-						"minimatch": "^3.0.4",
+						"minimatch": "^5.0.1",
 						"npm-package-arg": "^9.0.1",
 						"pacote": "^13.0.5",
 						"tar": "^6.1.0"
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0",
@@ -7615,14 +7581,14 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0"
 					}
 				},
 				"libnpmhook": {
-					"version": "8.0.2",
+					"version": "8.0.3",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7630,7 +7596,7 @@
 					}
 				},
 				"libnpmorg": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7638,7 +7604,7 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
 						"@npmcli/run-script": "^3.0.0",
@@ -7647,25 +7613,25 @@
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.2",
+					"version": "6.0.3",
 					"bundled": true,
 					"requires": {
 						"normalize-package-data": "^4.0.0",
 						"npm-package-arg": "^9.0.1",
 						"npm-registry-fetch": "^13.0.0",
 						"semver": "^7.1.3",
-						"ssri": "^8.0.1"
+						"ssri": "^9.0.0"
 					}
 				},
 				"libnpmsearch": {
-					"version": "5.0.2",
+					"version": "5.0.3",
 					"bundled": true,
 					"requires": {
 						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmteam": {
-					"version": "4.0.2",
+					"version": "4.0.3",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7673,23 +7639,22 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
 						"@npmcli/run-script": "^3.0.0",
 						"json-parse-even-better-errors": "^2.3.1",
 						"proc-log": "^2.0.0",
-						"semver": "^7.3.5",
-						"stringify-package": "^1.0.1"
+						"semver": "^7.3.5"
 					}
 				},
 				"lru-cache": {
-					"version": "7.7.1",
+					"version": "7.7.3",
 					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.1.1",
+					"version": "10.1.2",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
@@ -7707,14 +7672,14 @@
 						"negotiator": "^0.6.3",
 						"promise-retry": "^2.0.1",
 						"socks-proxy-agent": "^6.1.1",
-						"ssri": "^8.0.1"
+						"ssri": "^9.0.0"
 					}
 				},
 				"minimatch": {
-					"version": "3.1.2",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "^2.0.1"
 					}
 				},
 				"minipass": {
@@ -7851,7 +7816,7 @@
 					}
 				},
 				"npm-install-checks": {
-					"version": "4.0.0",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
 						"semver": "^7.1.1"
@@ -7871,20 +7836,20 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "4.0.0",
+					"version": "5.0.0",
 					"bundled": true,
 					"requires": {
 						"glob": "^7.2.0",
-						"ignore-walk": "^4.0.1",
+						"ignore-walk": "^5.0.1",
 						"npm-bundled": "^1.1.2",
 						"npm-normalize-package-bin": "^1.0.1"
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "7.0.0",
+					"version": "7.0.1",
 					"bundled": true,
 					"requires": {
-						"npm-install-checks": "^4.0.0",
+						"npm-install-checks": "^5.0.0",
 						"npm-normalize-package-bin": "^1.0.1",
 						"npm-package-arg": "^9.0.0",
 						"semver": "^7.3.5"
@@ -7944,12 +7909,12 @@
 					}
 				},
 				"pacote": {
-					"version": "13.0.5",
+					"version": "13.1.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
-						"@npmcli/promise-spawn": "^1.2.0",
+						"@npmcli/promise-spawn": "^3.0.0",
 						"@npmcli/run-script": "^3.0.1",
 						"cacache": "^16.0.0",
 						"chownr": "^2.0.0",
@@ -7958,7 +7923,7 @@
 						"minipass": "^3.1.6",
 						"mkdirp": "^1.0.4",
 						"npm-package-arg": "^9.0.0",
-						"npm-packlist": "^4.0.0",
+						"npm-packlist": "^5.0.0",
 						"npm-pick-manifest": "^7.0.0",
 						"npm-registry-fetch": "^13.0.1",
 						"proc-log": "^2.0.0",
@@ -7966,7 +7931,7 @@
 						"read-package-json": "^5.0.0",
 						"read-package-json-fast": "^2.0.3",
 						"rimraf": "^3.0.2",
-						"ssri": "^8.0.1",
+						"ssri": "^9.0.0",
 						"tar": "^6.1.11"
 					}
 				},
@@ -8026,7 +7991,7 @@
 					}
 				},
 				"read-cmd-shim": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true
 				},
 				"read-package-json": {
@@ -8087,19 +8052,10 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "7.3.5",
+					"version": "7.3.6",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "6.0.0",
-							"bundled": true,
-							"requires": {
-								"yallist": "^4.0.0"
-							}
-						}
+						"lru-cache": "^7.4.0"
 					}
 				},
 				"set-blocking": {
@@ -8156,7 +8112,7 @@
 					"bundled": true
 				},
 				"ssri": {
-					"version": "8.0.1",
+					"version": "9.0.0",
 					"bundled": true,
 					"requires": {
 						"minipass": "^3.1.1"
@@ -8177,10 +8133,6 @@
 						"is-fullwidth-code-point": "^3.0.0",
 						"strip-ansi": "^6.0.1"
 					}
-				},
-				"stringify-package": {
-					"version": "1.0.1",
-					"bundled": true
 				},
 				"strip-ansi": {
 					"version": "6.0.1",
@@ -8217,7 +8169,7 @@
 					"bundled": true
 				},
 				"treeverse": {
-					"version": "1.0.4",
+					"version": "2.0.0",
 					"bundled": true
 				},
 				"unique-filename": {
@@ -8699,18 +8651,11 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.6",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
 			"requires": {
-				"lru-cache": "^7.4.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.8.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
-					"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
-				}
+				"lru-cache": "^6.0.0"
 			}
 		},
 		"semver-diff": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._