### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -432,9 +432,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-			"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
+			"version": "17.0.25",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+			"integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -1431,9 +1431,9 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"node_modules/is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -5685,9 +5685,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "17.0.24",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-			"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
+			"version": "17.0.25",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
+			"integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6418,9 +6418,9 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-core-module": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
-			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
 			"requires": {
 				"has": "^1.0.3"
 			}


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._