### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
 			"dependencies": {
 				"@actions/http-client": "^1.0.11"
 			}
@@ -432,9 +432,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-			"integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+			"version": "17.0.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -448,9 +448,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-			"integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"node_modules/agent-base": {
 			"version": "6.0.2",
@@ -1733,9 +1733,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.14",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ==",
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
+			"integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
-			"integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
+			"integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2035,19 +2035,19 @@
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.1.0",
 				"@npmcli/fs": "^2.1.0",
-				"@npmcli/map-workspaces": "^2.0.2",
+				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.4",
+				"cacache": "^16.0.7",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
-				"cli-table3": "^0.6.1",
+				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
 				"hosted-git-info": "^5.0.0",
 				"ini": "^3.0.0",
@@ -2077,21 +2077,21 @@
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.0.2",
 				"npm-pick-manifest": "^7.0.1",
-				"npm-profile": "^6.0.2",
-				"npm-registry-fetch": "^13.1.0",
+				"npm-profile": "^6.0.3",
+				"npm-registry-fetch": "^13.1.1",
 				"npm-user-validate": "^1.0.1",
-				"npmlog": "^6.0.1",
+				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.1.1",
+				"pacote": "^13.3.0",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.0",
+				"read-package-json": "^5.0.1",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.6",
+				"semver": "^7.3.7",
 				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
@@ -2120,6 +2120,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
 		"node_modules/npm/node_modules/@gar/promisify": {
 			"version": "1.1.3",
 			"inBundle": true,
@@ -2131,13 +2140,13 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.0.6",
+			"version": "5.1.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
-				"@npmcli/map-workspaces": "^2.0.0",
+				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/metavuln-calculator": "^3.0.1",
 				"@npmcli/move-file": "^2.0.0",
 				"@npmcli/name-from-folder": "^1.0.1",
@@ -2145,7 +2154,7 @@
 				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.0",
 				"bin-links": "^3.0.0",
-				"cacache": "^16.0.0",
+				"cacache": "^16.0.6",
 				"common-ancestor-path": "^1.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
@@ -2156,7 +2165,7 @@
 				"npm-package-arg": "^9.0.0",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-registry-fetch": "^13.0.0",
-				"npmlog": "^6.0.1",
+				"npmlog": "^6.0.2",
 				"pacote": "^13.0.5",
 				"parse-conflict-json": "^2.0.1",
 				"proc-log": "^2.0.0",
@@ -2165,7 +2174,7 @@
 				"read-package-json-fast": "^2.0.2",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.5",
+				"semver": "^7.3.7",
 				"ssri": "^9.0.0",
 				"treeverse": "^2.0.0",
 				"walk-up-path": "^1.0.0"
@@ -2261,17 +2270,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "2.0.2",
+			"version": "2.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/name-from-folder": "^1.0.1",
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"minimatch": "^5.0.1",
 				"read-package-json-fast": "^2.0.3"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
@@ -2493,7 +2502,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.0.4",
+			"version": "16.0.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2501,7 +2510,7 @@
 				"@npmcli/move-file": "^2.0.0",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"infer-owner": "^1.0.4",
 				"lru-cache": "^7.7.1",
 				"minipass": "^3.1.6",
@@ -2575,7 +2584,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cli-table3": {
-			"version": "0.6.1",
+			"version": "0.6.2",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2585,7 +2594,7 @@
 				"node": "10.* || >= 12.*"
 			},
 			"optionalDependencies": {
-				"colors": "1.4.0"
+				"@colors/colors": "1.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/clone": {
@@ -2629,15 +2638,6 @@
 			"license": "ISC",
 			"bin": {
 				"color-support": "bin.js"
-			}
-		},
-		"node_modules/npm/node_modules/colors": {
-			"version": "1.4.0",
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/npm/node_modules/columnify": {
@@ -2806,42 +2806,22 @@
 			}
 		},
 		"node_modules/npm/node_modules/glob": {
-			"version": "7.2.0",
+			"version": "8.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^5.0.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm/node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"inBundle": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/npm/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/npm/node_modules/graceful-fs": {
@@ -3122,7 +3102,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.3",
+			"version": "4.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3132,7 +3112,7 @@
 				"chalk": "^4.1.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"npm-package-arg": "^9.0.1",
-				"npmlog": "^6.0.1",
+				"npmlog": "^6.0.2",
 				"pacote": "^13.0.5",
 				"proc-log": "^2.0.0",
 				"read": "^1.0.7",
@@ -3192,14 +3172,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.3",
+			"version": "6.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"normalize-package-data": "^4.0.0",
 				"npm-package-arg": "^9.0.1",
 				"npm-registry-fetch": "^13.0.0",
-				"semver": "^7.1.3",
+				"semver": "^7.3.7",
 				"ssri": "^9.0.0"
 			},
 			"engines": {
@@ -3230,7 +3210,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "3.0.3",
+			"version": "3.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3238,14 +3218,14 @@
 				"@npmcli/run-script": "^3.0.0",
 				"json-parse-even-better-errors": "^2.3.1",
 				"proc-log": "^2.0.0",
-				"semver": "^7.3.5"
+				"semver": "^7.3.7"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "7.7.3",
+			"version": "7.8.1",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3446,6 +3426,45 @@
 				"node": "^12.22 || ^14.13 || >=16"
 			}
 		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/glob": {
+			"version": "7.2.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/npm/node_modules/nopt": {
 			"version": "5.0.0",
 			"inBundle": true,
@@ -3523,11 +3542,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "5.0.0",
+			"version": "5.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"ignore-walk": "^5.0.1",
 				"npm-bundled": "^1.1.2",
 				"npm-normalize-package-bin": "^1.0.1"
@@ -3554,19 +3573,19 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "6.0.2",
+			"version": "6.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^13.0.0",
+				"npm-registry-fetch": "^13.0.1",
 				"proc-log": "^2.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "13.1.0",
+			"version": "13.1.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3588,17 +3607,17 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/npm/node_modules/npmlog": {
-			"version": "6.0.1",
+			"version": "6.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"are-we-there-yet": "^3.0.0",
 				"console-control-strings": "^1.1.0",
-				"gauge": "^4.0.0",
+				"gauge": "^4.0.3",
 				"set-blocking": "^2.0.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/once": {
@@ -3632,7 +3651,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.1.1",
+			"version": "13.3.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3762,17 +3781,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"normalize-package-data": "^4.0.0",
 				"npm-normalize-package-bin": "^1.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json-fast": {
@@ -3833,6 +3852,45 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/npm/node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/npm/node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"funding": [
@@ -3859,17 +3917,28 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.3.6",
+			"version": "7.3.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"lru-cache": "^7.4.0"
+				"lru-cache": "^6.0.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/npm/node_modules/set-blocking": {
@@ -4225,11 +4294,11 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-			"integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
 			"dependencies": {
-				"@types/retry": "^0.12.0",
+				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
@@ -5161,9 +5230,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+			"version": "4.6.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5339,9 +5408,9 @@
 	},
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
-			"integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
 			"requires": {
 				"@actions/http-client": "^1.0.11"
 			}
@@ -5685,9 +5754,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.25.tgz",
-			"integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==",
+			"version": "17.0.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
+			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -5701,9 +5770,9 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@types/retry": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-			"integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"agent-base": {
 			"version": "6.0.2",
@@ -6645,9 +6714,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.0.14",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-			"integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ=="
+			"version": "4.0.15",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
+			"integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -6797,28 +6866,28 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
-			"integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
+			"integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/arborist": "^5.0.4",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.1.0",
 				"@npmcli/fs": "^2.1.0",
-				"@npmcli/map-workspaces": "^2.0.2",
+				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.4",
+				"cacache": "^16.0.7",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
-				"cli-table3": "^0.6.1",
+				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
-				"glob": "^7.2.0",
+				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
 				"hosted-git-info": "^5.0.0",
 				"ini": "^3.0.0",
@@ -6848,21 +6917,21 @@
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.0.2",
 				"npm-pick-manifest": "^7.0.1",
-				"npm-profile": "^6.0.2",
-				"npm-registry-fetch": "^13.1.0",
+				"npm-profile": "^6.0.3",
+				"npm-registry-fetch": "^13.1.1",
 				"npm-user-validate": "^1.0.1",
-				"npmlog": "^6.0.1",
+				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.1.1",
+				"pacote": "^13.3.0",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.0",
+				"read-package-json": "^5.0.1",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
-				"semver": "^7.3.6",
+				"semver": "^7.3.7",
 				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
@@ -6873,6 +6942,11 @@
 				"write-file-atomic": "^4.0.1"
 			},
 			"dependencies": {
+				"@colors/colors": {
+					"version": "1.5.0",
+					"bundled": true,
+					"optional": true
+				},
 				"@gar/promisify": {
 					"version": "1.1.3",
 					"bundled": true
@@ -6882,12 +6956,12 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.0.6",
+					"version": "5.1.1",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
-						"@npmcli/map-workspaces": "^2.0.0",
+						"@npmcli/map-workspaces": "^2.0.3",
 						"@npmcli/metavuln-calculator": "^3.0.1",
 						"@npmcli/move-file": "^2.0.0",
 						"@npmcli/name-from-folder": "^1.0.1",
@@ -6895,7 +6969,7 @@
 						"@npmcli/package-json": "^2.0.0",
 						"@npmcli/run-script": "^3.0.0",
 						"bin-links": "^3.0.0",
-						"cacache": "^16.0.0",
+						"cacache": "^16.0.6",
 						"common-ancestor-path": "^1.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"json-stringify-nice": "^1.1.4",
@@ -6906,7 +6980,7 @@
 						"npm-package-arg": "^9.0.0",
 						"npm-pick-manifest": "^7.0.0",
 						"npm-registry-fetch": "^13.0.0",
-						"npmlog": "^6.0.1",
+						"npmlog": "^6.0.2",
 						"pacote": "^13.0.5",
 						"parse-conflict-json": "^2.0.1",
 						"proc-log": "^2.0.0",
@@ -6915,7 +6989,7 @@
 						"read-package-json-fast": "^2.0.2",
 						"readdir-scoped-modules": "^1.1.0",
 						"rimraf": "^3.0.2",
-						"semver": "^7.3.5",
+						"semver": "^7.3.7",
 						"ssri": "^9.0.0",
 						"treeverse": "^2.0.0",
 						"walk-up-path": "^1.0.0"
@@ -6978,11 +7052,11 @@
 					}
 				},
 				"@npmcli/map-workspaces": {
-					"version": "2.0.2",
+					"version": "2.0.3",
 					"bundled": true,
 					"requires": {
 						"@npmcli/name-from-folder": "^1.0.1",
-						"glob": "^7.2.0",
+						"glob": "^8.0.1",
 						"minimatch": "^5.0.1",
 						"read-package-json-fast": "^2.0.3"
 					}
@@ -7135,14 +7209,14 @@
 					}
 				},
 				"cacache": {
-					"version": "16.0.4",
+					"version": "16.0.7",
 					"bundled": true,
 					"requires": {
 						"@npmcli/fs": "^2.1.0",
 						"@npmcli/move-file": "^2.0.0",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
-						"glob": "^7.2.0",
+						"glob": "^8.0.1",
 						"infer-owner": "^1.0.4",
 						"lru-cache": "^7.7.1",
 						"minipass": "^3.1.6",
@@ -7190,10 +7264,10 @@
 					}
 				},
 				"cli-table3": {
-					"version": "0.6.1",
+					"version": "0.6.2",
 					"bundled": true,
 					"requires": {
-						"colors": "1.4.0",
+						"@colors/colors": "1.5.0",
 						"string-width": "^4.2.0"
 					}
 				},
@@ -7222,11 +7296,6 @@
 				"color-support": {
 					"version": "1.1.3",
 					"bundled": true
-				},
-				"colors": {
-					"version": "1.4.0",
-					"bundled": true,
-					"optional": true
 				},
 				"columnify": {
 					"version": "1.6.0",
@@ -7346,32 +7415,15 @@
 					}
 				},
 				"glob": {
-					"version": "7.2.0",
+					"version": "8.0.1",
 					"bundled": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
 						"inherits": "2",
-						"minimatch": "^3.0.4",
+						"minimatch": "^5.0.1",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
-					},
-					"dependencies": {
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"minimatch": {
-							"version": "3.1.2",
-							"bundled": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						}
 					}
 				},
 				"graceful-fs": {
@@ -7563,7 +7615,7 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.3",
+					"version": "4.0.5",
 					"bundled": true,
 					"requires": {
 						"@npmcli/arborist": "^5.0.0",
@@ -7572,7 +7624,7 @@
 						"chalk": "^4.1.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"npm-package-arg": "^9.0.1",
-						"npmlog": "^6.0.1",
+						"npmlog": "^6.0.2",
 						"pacote": "^13.0.5",
 						"proc-log": "^2.0.0",
 						"read": "^1.0.7",
@@ -7613,13 +7665,13 @@
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.3",
+					"version": "6.0.4",
 					"bundled": true,
 					"requires": {
 						"normalize-package-data": "^4.0.0",
 						"npm-package-arg": "^9.0.1",
 						"npm-registry-fetch": "^13.0.0",
-						"semver": "^7.1.3",
+						"semver": "^7.3.7",
 						"ssri": "^9.0.0"
 					}
 				},
@@ -7639,18 +7691,18 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "3.0.3",
+					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
 						"@npmcli/run-script": "^3.0.0",
 						"json-parse-even-better-errors": "^2.3.1",
 						"proc-log": "^2.0.0",
-						"semver": "^7.3.5"
+						"semver": "^7.3.7"
 					}
 				},
 				"lru-cache": {
-					"version": "7.7.3",
+					"version": "7.8.1",
 					"bundled": true
 				},
 				"make-fetch-happen": {
@@ -7782,6 +7834,35 @@
 						"semver": "^7.3.5",
 						"tar": "^6.1.2",
 						"which": "^2.0.2"
+					},
+					"dependencies": {
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"glob": {
+							"version": "7.2.0",
+							"bundled": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"minimatch": {
+							"version": "3.1.2",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
 					}
 				},
 				"nopt": {
@@ -7836,10 +7917,10 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "5.0.0",
+					"version": "5.0.2",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.2.0",
+						"glob": "^8.0.1",
 						"ignore-walk": "^5.0.1",
 						"npm-bundled": "^1.1.2",
 						"npm-normalize-package-bin": "^1.0.1"
@@ -7856,15 +7937,15 @@
 					}
 				},
 				"npm-profile": {
-					"version": "6.0.2",
+					"version": "6.0.3",
 					"bundled": true,
 					"requires": {
-						"npm-registry-fetch": "^13.0.0",
+						"npm-registry-fetch": "^13.0.1",
 						"proc-log": "^2.0.0"
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "13.1.0",
+					"version": "13.1.1",
 					"bundled": true,
 					"requires": {
 						"make-fetch-happen": "^10.0.6",
@@ -7881,12 +7962,12 @@
 					"bundled": true
 				},
 				"npmlog": {
-					"version": "6.0.1",
+					"version": "6.0.2",
 					"bundled": true,
 					"requires": {
 						"are-we-there-yet": "^3.0.0",
 						"console-control-strings": "^1.1.0",
-						"gauge": "^4.0.0",
+						"gauge": "^4.0.3",
 						"set-blocking": "^2.0.0"
 					}
 				},
@@ -7909,7 +7990,7 @@
 					}
 				},
 				"pacote": {
-					"version": "13.1.1",
+					"version": "13.3.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
@@ -7995,10 +8076,10 @@
 					"bundled": true
 				},
 				"read-package-json": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
-						"glob": "^7.2.0",
+						"glob": "^8.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"normalize-package-data": "^4.0.0",
 						"npm-normalize-package-bin": "^1.0.1"
@@ -8040,6 +8121,35 @@
 					"bundled": true,
 					"requires": {
 						"glob": "^7.1.3"
+					},
+					"dependencies": {
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"glob": {
+							"version": "7.2.0",
+							"bundled": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"minimatch": {
+							"version": "3.1.2",
+							"bundled": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						}
 					}
 				},
 				"safe-buffer": {
@@ -8052,10 +8162,19 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "7.3.6",
+					"version": "7.3.7",
 					"bundled": true,
 					"requires": {
-						"lru-cache": "^7.4.0"
+						"lru-cache": "^6.0.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "6.0.0",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
 					}
 				},
 				"set-blocking": {
@@ -8317,11 +8436,11 @@
 			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
 		},
 		"p-retry": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-			"integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
 			"requires": {
-				"@types/retry": "^0.12.0",
+				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
 			}
 		},
@@ -8999,9 +9118,9 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-			"integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+			"version": "4.6.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
 			"dev": true
 		},
 		"uglify-js": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._