### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
-			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
+			"integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
 			"dependencies": {
-				"@actions/http-client": "^1.0.11"
+				"@actions/http-client": "^2.0.1"
 			}
 		},
 		"node_modules/@actions/exec": {
@@ -35,22 +35,22 @@
 			}
 		},
 		"node_modules/@actions/github": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
-			"integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
+			"integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
 			"dependencies": {
-				"@actions/http-client": "^1.0.11",
+				"@actions/http-client": "^2.0.1",
 				"@octokit/core": "^3.6.0",
 				"@octokit/plugin-paginate-rest": "^2.17.0",
 				"@octokit/plugin-rest-endpoint-methods": "^5.13.0"
 			}
 		},
 		"node_modules/@actions/http-client": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-			"integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+			"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
 			"dependencies": {
-				"tunnel": "0.0.6"
+				"tunnel": "^0.0.6"
 			}
 		},
 		"node_modules/@actions/io": {
@@ -78,9 +78,9 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
+			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -432,9 +432,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+			"version": "17.0.34",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+			"integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -514,17 +514,17 @@
 		"node_modules/ansicolors": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-			"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+			"integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
 		},
 		"node_modules/argv-formatter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
-			"integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk="
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="
 		},
 		"node_modules/array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -537,7 +537,7 @@
 		"node_modules/arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -612,7 +612,7 @@
 		"node_modules/cardinal": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-			"integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+			"integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
 			"dependencies": {
 				"ansicolors": "~0.3.2",
 				"redeyed": "~2.1.0"
@@ -869,9 +869,9 @@
 			}
 		},
 		"node_modules/del": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.1.0.tgz",
+			"integrity": "sha512-OpcRktOt7G7HBfyxP0srBH4Djg4824EQORX8E1qvIhIzthNNArxxhrB/Mm7dRMiLi1nvFyUpDhzD2cTtbBhV8A==",
 			"dependencies": {
 				"globby": "^11.0.1",
 				"graceful-fs": "^4.2.4",
@@ -1189,14 +1189,14 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			},
@@ -1733,9 +1733,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
-			"integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==",
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
-			"integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.10.0.tgz",
+			"integrity": "sha512-6oo65q9Quv9mRPGZJufmSH+C/UFdgelwzRXiglT/2mDB50zdy/lZK5dFY0TJ9fJ/8gHqnxcX1NM206KLjTBMlQ==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2065,7 +2065,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.2",
+				"make-fetch-happen": "^10.1.3",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -2140,7 +2140,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.1.1",
+			"version": "5.2.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2494,7 +2494,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/builtins": {
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2883,7 +2883,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/https-proxy-agent": {
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2986,7 +2986,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip": {
-			"version": "1.1.5",
+			"version": "1.1.8",
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3010,7 +3010,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-core-module": {
-			"version": "2.8.1",
+			"version": "2.9.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3060,7 +3060,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff": {
-			"version": "5.0.1",
+			"version": "5.0.2",
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3225,7 +3225,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "7.8.1",
+			"version": "7.9.0",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3233,7 +3233,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.1.2",
+			"version": "10.1.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3542,7 +3542,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "5.0.2",
+			"version": "5.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3974,13 +3974,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "6.1.1",
+			"version": "6.2.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^6.0.2",
-				"debug": "^4.3.1",
-				"socks": "^2.6.1"
+				"debug": "^4.3.3",
+				"socks": "^2.6.2"
 			},
 			"engines": {
 				"node": ">= 10"
@@ -4805,9 +4805,9 @@
 			}
 		},
 		"node_modules/semver-regex": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-			"integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
 			"engines": {
 				"node": ">=8"
 			},
@@ -5243,9 +5243,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.15.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+			"version": "3.15.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+			"integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -5408,11 +5408,11 @@
 	},
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.0.tgz",
-			"integrity": "sha512-XirM+Zo/PFlA+1h+i4bkfvagujta+LIM2AOSzPbt8JqXbbuxb1HTB+FqIyaKmue9yiCx/JIJY6pXsOl3+T8JGw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
+			"integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
 			"requires": {
-				"@actions/http-client": "^1.0.11"
+				"@actions/http-client": "^2.0.1"
 			}
 		},
 		"@actions/exec": {
@@ -5424,22 +5424,22 @@
 			}
 		},
 		"@actions/github": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.1.tgz",
-			"integrity": "sha512-JZGyPM9ektb8NVTTI/2gfJ9DL7Rk98tQ7OVyTlgTuaQroariRBsOnzjy0I2EarX4xUZpK88YyO503fhmjFdyAg==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
+			"integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
 			"requires": {
-				"@actions/http-client": "^1.0.11",
+				"@actions/http-client": "^2.0.1",
 				"@octokit/core": "^3.6.0",
 				"@octokit/plugin-paginate-rest": "^2.17.0",
 				"@octokit/plugin-rest-endpoint-methods": "^5.13.0"
 			}
 		},
 		"@actions/http-client": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-			"integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+			"integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
 			"requires": {
-				"tunnel": "0.0.6"
+				"tunnel": "^0.0.6"
 			}
 		},
 		"@actions/io": {
@@ -5461,9 +5461,9 @@
 			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
 		},
 		"@babel/highlight": {
-			"version": "7.17.9",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
-			"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
+			"version": "7.17.12",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
+			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
@@ -5754,9 +5754,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.31.tgz",
-			"integrity": "sha512-AR0x5HbXGqkEx9CadRH3EBYx/VkiUgZIhP4wvPn/+5KIsgpNoyFaRlVe0Zlx9gRtg8fA06a9tskE2MSN7TcG4Q==",
+			"version": "17.0.34",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
+			"integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -5815,17 +5815,17 @@
 		"ansicolors": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-			"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
+			"integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg=="
 		},
 		"argv-formatter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
-			"integrity": "sha1-oMoMvCmltz6Dbuvhy/bF4OTrgvk="
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="
 		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="
 		},
 		"array-union": {
 			"version": "2.1.0",
@@ -5835,7 +5835,7 @@
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -5892,7 +5892,7 @@
 		"cardinal": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-			"integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
+			"integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
 			"requires": {
 				"ansicolors": "~0.3.2",
 				"redeyed": "~2.1.0"
@@ -6080,9 +6080,9 @@
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"del": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.1.0.tgz",
+			"integrity": "sha512-OpcRktOt7G7HBfyxP0srBH4Djg4824EQORX8E1qvIhIzthNNArxxhrB/Mm7dRMiLi1nvFyUpDhzD2cTtbBhV8A==",
 			"requires": {
 				"globby": "^11.0.1",
 				"graceful-fs": "^4.2.4",
@@ -6317,14 +6317,14 @@
 			}
 		},
 		"glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
+				"minimatch": "^3.1.1",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
 			}
@@ -6714,9 +6714,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.0.15",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
-			"integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q=="
+			"version": "4.0.16",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
+			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -6866,9 +6866,9 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.9.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.9.0.tgz",
-			"integrity": "sha512-4mhU5nEv7ktvHmJnM2nmWP2Zk4cCsD26imX+dvZ76HOuFUnIpU6+i1MWuoMg8N/xWHQgB0d2/ybWEGgJR9M/pw==",
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.10.0.tgz",
+			"integrity": "sha512-6oo65q9Quv9mRPGZJufmSH+C/UFdgelwzRXiglT/2mDB50zdy/lZK5dFY0TJ9fJ/8gHqnxcX1NM206KLjTBMlQ==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/arborist": "^5.0.4",
@@ -6905,7 +6905,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.2",
+				"make-fetch-happen": "^10.1.3",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -6956,7 +6956,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.1.1",
+					"version": "5.2.0",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -7202,7 +7202,7 @@
 					}
 				},
 				"builtins": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
 						"semver": "^7.0.0"
@@ -7466,7 +7466,7 @@
 					}
 				},
 				"https-proxy-agent": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"requires": {
 						"agent-base": "6",
@@ -7537,7 +7537,7 @@
 					}
 				},
 				"ip": {
-					"version": "1.1.5",
+					"version": "1.1.8",
 					"bundled": true
 				},
 				"ip-regex": {
@@ -7552,7 +7552,7 @@
 					}
 				},
 				"is-core-module": {
-					"version": "2.8.1",
+					"version": "2.9.0",
 					"bundled": true,
 					"requires": {
 						"has": "^1.0.3"
@@ -7583,7 +7583,7 @@
 					"bundled": true
 				},
 				"just-diff": {
-					"version": "5.0.1",
+					"version": "5.0.2",
 					"bundled": true
 				},
 				"just-diff-apply": {
@@ -7702,11 +7702,11 @@
 					}
 				},
 				"lru-cache": {
-					"version": "7.8.1",
+					"version": "7.9.0",
 					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.1.2",
+					"version": "10.1.3",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
@@ -7917,7 +7917,7 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "5.0.2",
+					"version": "5.0.3",
 					"bundled": true,
 					"requires": {
 						"glob": "^8.0.1",
@@ -8198,12 +8198,12 @@
 					}
 				},
 				"socks-proxy-agent": {
-					"version": "6.1.1",
+					"version": "6.2.0",
 					"bundled": true,
 					"requires": {
 						"agent-base": "^6.0.2",
-						"debug": "^4.3.1",
-						"socks": "^2.6.1"
+						"debug": "^4.3.3",
+						"socks": "^2.6.2"
 					}
 				},
 				"spdx-correct": {
@@ -8793,9 +8793,9 @@
 			}
 		},
 		"semver-regex": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-			"integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ=="
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+			"integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA=="
 		},
 		"shebang-command": {
 			"version": "2.0.0",
@@ -9124,9 +9124,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.15.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-			"integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+			"version": "3.15.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+			"integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._