### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -125,7 +125,7 @@
 		"node_modules/@babel/highlight/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
@@ -869,9 +869,9 @@
 			}
 		},
 		"node_modules/del": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.1.0.tgz",
-			"integrity": "sha512-OpcRktOt7G7HBfyxP0srBH4Djg4824EQORX8E1qvIhIzthNNArxxhrB/Mm7dRMiLi1nvFyUpDhzD2cTtbBhV8A==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+			"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
 			"dependencies": {
 				"globby": "^11.0.1",
 				"graceful-fs": "^4.2.4",
@@ -1954,9 +1954,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.10.0.tgz",
-			"integrity": "sha512-6oo65q9Quv9mRPGZJufmSH+C/UFdgelwzRXiglT/2mDB50zdy/lZK5dFY0TJ9fJ/8gHqnxcX1NM206KLjTBMlQ==",
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.11.0.tgz",
+			"integrity": "sha512-4qmtwHa28J4SPmwCNoQI07KIF/ljmBhhuqG+xNXsIIRpwdKB5OXkMIGfH6KlThR6kzusxlkgR7t1haFDB88dcQ==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2040,7 +2040,7 @@
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.7",
+				"cacache": "^16.1.0",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -2065,7 +2065,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.3",
+				"make-fetch-happen": "^10.1.5",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -2082,7 +2082,7 @@
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.3.0",
+				"pacote": "^13.4.1",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
@@ -2092,7 +2092,7 @@
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.7",
-				"ssri": "^9.0.0",
+				"ssri": "^9.0.1",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
@@ -2502,7 +2502,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.0.7",
+			"version": "16.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3159,13 +3159,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.0.3",
+			"version": "4.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/run-script": "^3.0.0",
 				"npm-package-arg": "^9.0.1",
-				"pacote": "^13.0.5"
+				"pacote": "^13.5.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -3233,12 +3233,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.1.3",
+			"version": "10.1.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.2.1",
-				"cacache": "^16.0.2",
+				"cacache": "^16.1.0",
 				"http-cache-semantics": "^4.1.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -3542,7 +3542,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "5.0.3",
+			"version": "5.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3651,7 +3651,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.3.0",
+			"version": "13.5.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3666,7 +3666,7 @@
 				"minipass": "^3.1.6",
 				"mkdirp": "^1.0.4",
 				"npm-package-arg": "^9.0.0",
-				"npm-packlist": "^5.0.0",
+				"npm-packlist": "^5.1.0",
 				"npm-pick-manifest": "^7.0.0",
 				"npm-registry-fetch": "^13.0.1",
 				"proc-log": "^2.0.0",
@@ -4015,7 +4015,7 @@
 			"license": "CC0-1.0"
 		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "9.0.0",
+			"version": "9.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4887,7 +4887,7 @@
 		"node_modules/signale/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/signale/node_modules/figures": {
 			"version": "2.0.0",
@@ -5230,9 +5230,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+			"integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5499,7 +5499,7 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -6080,9 +6080,9 @@
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"del": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-6.1.0.tgz",
-			"integrity": "sha512-OpcRktOt7G7HBfyxP0srBH4Djg4824EQORX8E1qvIhIzthNNArxxhrB/Mm7dRMiLi1nvFyUpDhzD2cTtbBhV8A==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+			"integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
 			"requires": {
 				"globby": "^11.0.1",
 				"graceful-fs": "^4.2.4",
@@ -6866,9 +6866,9 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.10.0.tgz",
-			"integrity": "sha512-6oo65q9Quv9mRPGZJufmSH+C/UFdgelwzRXiglT/2mDB50zdy/lZK5dFY0TJ9fJ/8gHqnxcX1NM206KLjTBMlQ==",
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.11.0.tgz",
+			"integrity": "sha512-4qmtwHa28J4SPmwCNoQI07KIF/ljmBhhuqG+xNXsIIRpwdKB5OXkMIGfH6KlThR6kzusxlkgR7t1haFDB88dcQ==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/arborist": "^5.0.4",
@@ -6880,7 +6880,7 @@
 				"@npmcli/run-script": "^3.0.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.0.7",
+				"cacache": "^16.1.0",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
@@ -6905,7 +6905,7 @@
 				"libnpmsearch": "^5.0.2",
 				"libnpmteam": "^4.0.2",
 				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.3",
+				"make-fetch-happen": "^10.1.5",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -6922,7 +6922,7 @@
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.3.0",
+				"pacote": "^13.4.1",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
@@ -6932,7 +6932,7 @@
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.7",
-				"ssri": "^9.0.0",
+				"ssri": "^9.0.1",
 				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
@@ -7209,7 +7209,7 @@
 					}
 				},
 				"cacache": {
-					"version": "16.0.7",
+					"version": "16.1.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/fs": "^2.1.0",
@@ -7656,12 +7656,12 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.0.3",
+					"version": "4.1.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/run-script": "^3.0.0",
 						"npm-package-arg": "^9.0.1",
-						"pacote": "^13.0.5"
+						"pacote": "^13.5.0"
 					}
 				},
 				"libnpmpublish": {
@@ -7706,11 +7706,11 @@
 					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.1.3",
+					"version": "10.1.5",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
-						"cacache": "^16.0.2",
+						"cacache": "^16.1.0",
 						"http-cache-semantics": "^4.1.0",
 						"http-proxy-agent": "^5.0.0",
 						"https-proxy-agent": "^5.0.0",
@@ -7917,7 +7917,7 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "5.0.3",
+					"version": "5.1.0",
 					"bundled": true,
 					"requires": {
 						"glob": "^8.0.1",
@@ -7990,7 +7990,7 @@
 					}
 				},
 				"pacote": {
-					"version": "13.3.0",
+					"version": "13.5.0",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
@@ -8004,7 +8004,7 @@
 						"minipass": "^3.1.6",
 						"mkdirp": "^1.0.4",
 						"npm-package-arg": "^9.0.0",
-						"npm-packlist": "^5.0.0",
+						"npm-packlist": "^5.1.0",
 						"npm-pick-manifest": "^7.0.0",
 						"npm-registry-fetch": "^13.0.1",
 						"proc-log": "^2.0.0",
@@ -8231,7 +8231,7 @@
 					"bundled": true
 				},
 				"ssri": {
-					"version": "9.0.0",
+					"version": "9.0.1",
 					"bundled": true,
 					"requires": {
 						"minipass": "^3.1.1"
@@ -8854,7 +8854,7 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 				},
 				"figures": {
 					"version": "2.0.0",
@@ -9118,9 +9118,9 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-			"integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+			"integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
 			"dev": true
 		},
 		"uglify-js": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._