### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
 		"node_modules/@babel/highlight/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"engines": {
 				"node": ">=4"
 			}
@@ -432,9 +432,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+			"version": "17.0.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
+			"integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -692,7 +692,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/conventional-changelog-angular": {
 			"version": "5.0.13",
@@ -835,7 +835,7 @@
 		"node_modules/decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -843,7 +843,7 @@
 		"node_modules/decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
 			"dependencies": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -933,7 +933,7 @@
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
 			"dependencies": {
 				"readable-stream": "^2.0.2"
 			}
@@ -975,7 +975,7 @@
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -1091,7 +1091,7 @@
 		"node_modules/from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
 			"dependencies": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -1132,7 +1132,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -1161,7 +1161,7 @@
 		"node_modules/git-log-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
-			"integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
 			"dependencies": {
 				"argv-formatter": "~1.0.0",
 				"spawn-error-forwarder": "~1.0.0",
@@ -1394,7 +1394,7 @@
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1428,7 +1428,7 @@
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"node_modules/is-core-module": {
 			"version": "2.9.0",
@@ -1444,7 +1444,7 @@
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1503,7 +1503,7 @@
 		"node_modules/is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1530,7 +1530,7 @@
 		"node_modules/is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
 			"dependencies": {
 				"text-extensions": "^1.0.0"
 			},
@@ -1541,12 +1541,12 @@
 		"node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/issue-parser": {
 			"version": "6.0.0",
@@ -1589,7 +1589,7 @@
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
@@ -1605,7 +1605,7 @@
 		"node_modules/jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
 			"engines": [
 				"node >= 0.2.0"
 			]
@@ -1641,7 +1641,7 @@
 		"node_modules/load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^4.0.0",
@@ -1683,32 +1683,32 @@
 		"node_modules/lodash.capitalize": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
-			"integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="
 		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g=="
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"node_modules/lodash.uniqby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -4412,7 +4412,7 @@
 		"node_modules/pkg-conf/node_modules/find-up": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 			"dependencies": {
 				"locate-path": "^2.0.0"
 			},
@@ -4423,7 +4423,7 @@
 		"node_modules/pkg-conf/node_modules/locate-path": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 			"dependencies": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
@@ -4892,7 +4892,7 @@
 		"node_modules/signale/node_modules/figures": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
 			"dependencies": {
 				"escape-string-regexp": "^1.0.5"
 			},
@@ -4903,7 +4903,7 @@
 		"node_modules/signale/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"engines": {
 				"node": ">=4"
 			}
@@ -5504,7 +5504,7 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 				},
 				"supports-color": {
 					"version": "5.5.0",
@@ -5754,9 +5754,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+			"version": "17.0.36",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
+			"integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -5952,7 +5952,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"conventional-changelog-angular": {
 			"version": "5.0.13",
@@ -6056,12 +6056,12 @@
 		"decamelize": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -6128,7 +6128,7 @@
 		"duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
 			"requires": {
 				"readable-stream": "^2.0.2"
 			}
@@ -6164,7 +6164,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 		},
 		"esprima": {
 			"version": "4.0.1",
@@ -6243,7 +6243,7 @@
 		"from2": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -6267,7 +6267,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -6287,7 +6287,7 @@
 		"git-log-parser": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
-			"integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
+			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
 			"requires": {
 				"argv-formatter": "~1.0.0",
 				"spawn-error-forwarder": "~1.0.0",
@@ -6456,7 +6456,7 @@
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6484,7 +6484,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"is-core-module": {
 			"version": "2.9.0",
@@ -6497,7 +6497,7 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -6535,7 +6535,7 @@
 		"is-plain-obj": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
 		},
 		"is-plain-object": {
 			"version": "5.0.0",
@@ -6550,7 +6550,7 @@
 		"is-text-path": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
 			"requires": {
 				"text-extensions": "^1.0.0"
 			}
@@ -6558,12 +6558,12 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
 		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"issue-parser": {
 			"version": "6.0.0",
@@ -6600,7 +6600,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
 		"jsonfile": {
 			"version": "6.1.0",
@@ -6614,7 +6614,7 @@
 		"jsonparse": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
 		},
 		"JSONStream": {
 			"version": "1.3.5",
@@ -6638,7 +6638,7 @@
 		"load-json-file": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"parse-json": "^4.0.0",
@@ -6673,32 +6673,32 @@
 		"lodash.capitalize": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
-			"integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="
 		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+			"integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g=="
 		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"lodash.uniqby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -8515,7 +8515,7 @@
 				"find-up": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
 					"requires": {
 						"locate-path": "^2.0.0"
 					}
@@ -8523,7 +8523,7 @@
 				"locate-path": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
@@ -8859,7 +8859,7 @@
 				"figures": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
 					}
@@ -8867,7 +8867,7 @@
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 				},
 				"supports-color": {
 					"version": "5.5.0",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._