### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,30 +60,30 @@
 			"integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dependencies": {
-				"@babel/highlight": "^7.16.7"
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -231,16 +231,16 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+			"version": "12.11.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+			"integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-			"integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+			"version": "2.21.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+			"integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
 			"dependencies": {
-				"@octokit/types": "^6.34.0"
+				"@octokit/types": "^6.40.0"
 			},
 			"peerDependencies": {
 				"@octokit/core": ">=2"
@@ -255,11 +255,11 @@
 			}
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-			"integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+			"version": "5.16.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+			"integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
 			"dependencies": {
-				"@octokit/types": "^6.34.0",
+				"@octokit/types": "^6.39.0",
 				"deprecation": "^2.3.1"
 			},
 			"peerDependencies": {
@@ -290,22 +290,150 @@
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "18.12.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-			"integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
+			"integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
 			"dependencies": {
-				"@octokit/core": "^3.5.1",
-				"@octokit/plugin-paginate-rest": "^2.16.8",
+				"@octokit/core": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^4.0.0",
 				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+				"@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
+			"integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+			"dependencies": {
+				"@octokit/types": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/core": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
+			"integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+			"dependencies": {
+				"@octokit/auth-token": "^3.0.0",
+				"@octokit/graphql": "^5.0.0",
+				"@octokit/request": "^6.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^7.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
+			"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+			"dependencies": {
+				"@octokit/types": "^7.0.0",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
+			"integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+			"dependencies": {
+				"@octokit/request": "^6.0.0",
+				"@octokit/types": "^7.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+			"version": "13.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.6.0.tgz",
+			"integrity": "sha512-bxftLwoZ2J6zsU1rzRvk0O32j7lVB0NWWn+P5CDHn9zPzytasR3hdAeXlTngRDkqv1LyEeuy5psVnDkmOSwrcQ=="
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.0.tgz",
+			"integrity": "sha512-8otLCIK9esfmOCY14CBnG/xPqv0paf14rc+s9tHpbOpeFwrv5CnECKW1qdqMAT60ngAa9eB1bKQ+l2YCpi0HPQ==",
+			"dependencies": {
+				"@octokit/types": "^7.2.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=4"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "6.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.4.0.tgz",
+			"integrity": "sha512-YP4eUqZ6vORy/eZOTdil1ZSrMt0kv7i/CVw+HhC2C0yJN+IqTc/rot957JQ7JfyeJD6HZOjLg6Jp1o9cPhI9KA==",
+			"dependencies": {
+				"@octokit/types": "^7.2.0",
+				"deprecation": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=3"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
+			"integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+			"dependencies": {
+				"@octokit/endpoint": "^7.0.0",
+				"@octokit/request-error": "^3.0.0",
+				"@octokit/types": "^7.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.7",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
+			"integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+			"dependencies": {
+				"@octokit/types": "^7.0.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/types": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.2.0.tgz",
+			"integrity": "sha512-pYQ/a1U6mHptwhGyp6SvsiM4bWP2s3V95olUeTxas85D/2kN78yN5C8cGN+P4LwJSWUqIEyvq0Qn2WUn6NQRjw==",
+			"dependencies": {
+				"@octokit/openapi-types": "^13.6.0"
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-			"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
 			"dependencies": {
-				"@octokit/openapi-types": "^11.2.0"
+				"@octokit/openapi-types": "^12.11.0"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer": {
@@ -337,12 +465,12 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
-			"integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
+			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
 			"dependencies": {
-				"@octokit/rest": "^18.0.0",
-				"@semantic-release/error": "^2.2.0",
+				"@octokit/rest": "^19.0.0",
+				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
@@ -364,11 +492,6 @@
 			"peerDependencies": {
 				"semantic-release": ">=18.0.0-beta.1"
 			}
-		},
-		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
 		},
 		"node_modules/@semantic-release/npm": {
 			"version": "9.0.1",
@@ -433,9 +556,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.0.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-			"integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+			"version": "18.7.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -1432,9 +1555,9 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"node_modules/is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -1734,9 +1857,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
-			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -1955,9 +2078,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.12.1.tgz",
-			"integrity": "sha512-0yOlhfgu1UzP6UijnaFuIS2bES2H9D90EA5OVsf2iOZw7VBrjntXKEwKfCaFA6vMVWkCP8qnPwCxxPdnDVwlNw==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.0.tgz",
+			"integrity": "sha512-Af+oxQyq+ZY0M3ygaXs4T4DVbN8HU0XjLMK9ghXLh48u16OQoEYXazx8miUM2h1qLMgTuEwhhuVlCNDkKLOcmg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -1966,6 +2089,7 @@
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
 				"@npmcli/run-script",
 				"abbrev",
 				"archy",
@@ -1976,6 +2100,7 @@
 				"cli-table3",
 				"columnify",
 				"fastest-levenshtein",
+				"fs-minipass",
 				"glob",
 				"graceful-fs",
 				"hosted-git-info",
@@ -1995,6 +2120,7 @@
 				"libnpmteam",
 				"libnpmversion",
 				"make-fetch-happen",
+				"minimatch",
 				"minipass",
 				"minipass-pipeline",
 				"mkdirp",
@@ -2011,6 +2137,7 @@
 				"npm-user-validate",
 				"npmlog",
 				"opener",
+				"p-map",
 				"pacote",
 				"parse-conflict-json",
 				"proc-log",
@@ -2032,63 +2159,67 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.4",
+				"@npmcli/arborist": "^5.6.1",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/config": "^4.1.0",
+				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/run-script": "^3.0.1",
+				"@npmcli/promise-spawn": "*",
+				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.1.0",
+				"cacache": "^16.1.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
+				"fs-minipass": "*",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.0.0",
-				"ini": "^3.0.0",
+				"hosted-git-info": "^5.1.0",
+				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
-				"libnpmaccess": "^6.0.2",
-				"libnpmdiff": "^4.0.2",
-				"libnpmexec": "^4.0.2",
-				"libnpmfund": "^3.0.1",
-				"libnpmhook": "^8.0.2",
-				"libnpmorg": "^4.0.2",
-				"libnpmpack": "^4.0.2",
-				"libnpmpublish": "^6.0.2",
-				"libnpmsearch": "^5.0.2",
-				"libnpmteam": "^4.0.2",
-				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.6",
+				"libnpmaccess": "^6.0.4",
+				"libnpmdiff": "^4.0.5",
+				"libnpmexec": "^4.0.12",
+				"libnpmfund": "^3.0.3",
+				"libnpmhook": "^8.0.4",
+				"libnpmorg": "^4.0.4",
+				"libnpmpack": "^4.1.3",
+				"libnpmpublish": "^6.0.5",
+				"libnpmsearch": "^5.0.4",
+				"libnpmteam": "^4.0.4",
+				"libnpmversion": "^3.0.7",
+				"make-fetch-happen": "^10.2.0",
+				"minimatch": "*",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
 				"mkdirp-infer-owner": "^2.0.0",
 				"ms": "^2.1.2",
-				"node-gyp": "^9.0.0",
-				"nopt": "^5.0.0",
+				"node-gyp": "^9.1.0",
+				"nopt": "^6.0.0",
 				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^5.0.0",
-				"npm-package-arg": "^9.0.2",
-				"npm-pick-manifest": "^7.0.1",
-				"npm-profile": "^6.0.3",
-				"npm-registry-fetch": "^13.1.1",
+				"npm-package-arg": "^9.1.0",
+				"npm-pick-manifest": "^7.0.2",
+				"npm-profile": "^6.2.0",
+				"npm-registry-fetch": "^13.3.1",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.6.0",
+				"p-map": "^4.0.0",
+				"pacote": "^13.6.2",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.1",
+				"read-package-json": "^5.0.2",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
@@ -2141,7 +2272,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.2.1",
+			"version": "5.6.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2153,21 +2284,23 @@
 				"@npmcli/name-from-folder": "^1.0.1",
 				"@npmcli/node-gyp": "^2.0.0",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/run-script": "^3.0.0",
-				"bin-links": "^3.0.0",
-				"cacache": "^16.0.6",
+				"@npmcli/query": "^1.2.0",
+				"@npmcli/run-script": "^4.1.3",
+				"bin-links": "^3.0.3",
+				"cacache": "^16.1.3",
 				"common-ancestor-path": "^1.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
+				"minimatch": "^5.1.0",
 				"mkdirp": "^1.0.4",
 				"mkdirp-infer-owner": "^2.0.0",
-				"nopt": "^5.0.0",
+				"nopt": "^6.0.0",
 				"npm-install-checks": "^5.0.0",
 				"npm-package-arg": "^9.0.0",
-				"npm-pick-manifest": "^7.0.0",
+				"npm-pick-manifest": "^7.0.2",
 				"npm-registry-fetch": "^13.0.0",
 				"npmlog": "^6.0.2",
-				"pacote": "^13.0.5",
+				"pacote": "^13.6.1",
 				"parse-conflict-json": "^2.0.1",
 				"proc-log": "^2.0.0",
 				"promise-all-reject-late": "^1.0.0",
@@ -2196,14 +2329,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "4.1.0",
+			"version": "4.2.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/map-workspaces": "^2.0.2",
 				"ini": "^3.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
-				"nopt": "^5.0.0",
+				"nopt": "^6.0.0",
 				"proc-log": "^2.0.0",
 				"read-package-json-fast": "^2.0.3",
 				"semver": "^7.3.5",
@@ -2225,7 +2358,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "2.1.0",
+			"version": "2.1.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2237,7 +2370,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2270,8 +2403,16 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+			"version": "1.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^1.0.1"
+			}
+		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "2.0.3",
+			"version": "2.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2285,7 +2426,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2299,7 +2440,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/move-file": {
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2345,15 +2486,29 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/@npmcli/query": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^9.1.0",
+				"postcss-selector-parser": "^6.0.10",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "3.0.2",
+			"version": "4.2.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/node-gyp": "^2.0.0",
 				"@npmcli/promise-spawn": "^3.0.0",
 				"node-gyp": "^9.0.0",
-				"read-package-json-fast": "^2.0.3"
+				"read-package-json-fast": "^2.0.3",
+				"which": "^2.0.2"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -2441,7 +2596,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/are-we-there-yet": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2449,7 +2604,7 @@
 				"readable-stream": "^3.6.0"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/asap": {
@@ -2463,17 +2618,25 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "3.0.1",
+			"version": "3.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"cmd-shim": "^5.0.0",
 				"mkdirp-infer-owner": "^2.0.0",
-				"npm-normalize-package-bin": "^1.0.0",
+				"npm-normalize-package-bin": "^2.0.0",
 				"read-cmd-shim": "^3.0.0",
 				"rimraf": "^3.0.0",
 				"write-file-atomic": "^4.0.0"
 			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
@@ -2503,7 +2666,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "16.1.0",
+			"version": "16.1.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2524,7 +2687,7 @@
 				"rimraf": "^3.0.2",
 				"ssri": "^9.0.0",
 				"tar": "^6.1.11",
-				"unique-filename": "^1.1.1"
+				"unique-filename": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -2668,6 +2831,17 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
+		"node_modules/npm/node_modules/cssesc": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/npm/node_modules/debug": {
 			"version": "4.3.4",
 			"inBundle": true,
@@ -2728,7 +2902,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "5.0.0",
+			"version": "5.1.0",
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -2854,14 +3028,14 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "5.0.0",
+			"version": "5.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^7.5.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -2961,7 +3135,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -2986,7 +3160,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip": {
-			"version": "1.1.8",
+			"version": "2.0.0",
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -3010,7 +3184,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-core-module": {
-			"version": "2.9.0",
+			"version": "2.10.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3060,17 +3234,17 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff": {
-			"version": "5.0.2",
+			"version": "5.1.1",
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff-apply": {
-			"version": "5.2.0",
+			"version": "5.4.1",
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "6.0.3",
+			"version": "6.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3084,17 +3258,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "4.0.3",
+			"version": "4.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/disparity-colors": "^2.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"binary-extensions": "^2.2.0",
-				"diff": "^5.0.0",
+				"diff": "^5.1.0",
 				"minimatch": "^5.0.1",
 				"npm-package-arg": "^9.0.1",
-				"pacote": "^13.0.5",
+				"pacote": "^13.6.1",
 				"tar": "^6.1.0"
 			},
 			"engines": {
@@ -3102,21 +3276,23 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.6",
+			"version": "4.0.12",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.0.0",
+				"@npmcli/arborist": "^5.6.1",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/run-script": "^3.0.0",
+				"@npmcli/fs": "^2.1.1",
+				"@npmcli/run-script": "^4.2.0",
 				"chalk": "^4.1.0",
 				"mkdirp-infer-owner": "^2.0.0",
 				"npm-package-arg": "^9.0.1",
 				"npmlog": "^6.0.2",
-				"pacote": "^13.0.5",
+				"pacote": "^13.6.1",
 				"proc-log": "^2.0.0",
 				"read": "^1.0.7",
 				"read-package-json-fast": "^2.0.2",
+				"semver": "^7.3.7",
 				"walk-up-path": "^1.0.0"
 			},
 			"engines": {
@@ -3124,18 +3300,18 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.0.0"
+				"@npmcli/arborist": "^5.6.1"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "8.0.3",
+			"version": "8.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3147,7 +3323,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3159,20 +3335,20 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "4.1.0",
+			"version": "4.1.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/run-script": "^3.0.0",
+				"@npmcli/run-script": "^4.1.3",
 				"npm-package-arg": "^9.0.1",
-				"pacote": "^13.5.0"
+				"pacote": "^13.6.1"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "6.0.4",
+			"version": "6.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3187,7 +3363,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "5.0.3",
+			"version": "5.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3198,7 +3374,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3210,12 +3386,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "3.0.4",
+			"version": "3.0.7",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/git": "^3.0.0",
-				"@npmcli/run-script": "^3.0.0",
+				"@npmcli/run-script": "^4.1.3",
 				"json-parse-even-better-errors": "^2.3.1",
 				"proc-log": "^2.0.0",
 				"semver": "^7.3.7"
@@ -3225,7 +3401,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "7.9.0",
+			"version": "7.13.2",
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -3233,7 +3409,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "10.1.6",
+			"version": "10.2.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3251,7 +3427,7 @@
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.3",
 				"promise-retry": "^2.0.1",
-				"socks-proxy-agent": "^6.1.1",
+				"socks-proxy-agent": "^7.0.0",
 				"ssri": "^9.0.0"
 			},
 			"engines": {
@@ -3270,7 +3446,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass": {
-			"version": "3.1.6",
+			"version": "3.3.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3292,7 +3468,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3404,7 +3580,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "9.0.0",
+			"version": "9.1.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3465,7 +3641,7 @@
 				"node": "*"
 			}
 		},
-		"node_modules/npm/node_modules/nopt": {
+		"node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
 			"version": "5.0.0",
 			"inBundle": true,
 			"license": "ISC",
@@ -3479,8 +3655,22 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "6.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^1.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -3490,7 +3680,7 @@
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
@@ -3505,11 +3695,22 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "1.1.2",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-normalize-package-bin": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
@@ -3529,11 +3730,12 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "9.0.2",
+			"version": "9.1.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"hosted-git-info": "^5.0.0",
+				"proc-log": "^2.0.1",
 				"semver": "^7.3.5",
 				"validate-npm-package-name": "^4.0.0"
 			},
@@ -3542,14 +3744,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "5.1.0",
+			"version": "5.1.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"glob": "^8.0.1",
 				"ignore-walk": "^5.0.1",
-				"npm-bundled": "^1.1.2",
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-bundled": "^2.0.0",
+				"npm-normalize-package-bin": "^2.0.0"
 			},
 			"bin": {
 				"npm-packlist": "bin/index.js"
@@ -3558,13 +3760,21 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "7.0.1",
+			"version": "7.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"npm-install-checks": "^5.0.0",
-				"npm-normalize-package-bin": "^1.0.1",
+				"npm-normalize-package-bin": "^2.0.0",
 				"npm-package-arg": "^9.0.0",
 				"semver": "^7.3.5"
 			},
@@ -3572,8 +3782,16 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/npm-profile": {
-			"version": "6.0.3",
+			"version": "6.2.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3585,7 +3803,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "13.1.1",
+			"version": "13.3.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3651,14 +3869,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "13.6.0",
+			"version": "13.6.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@npmcli/git": "^3.0.0",
 				"@npmcli/installed-package-contents": "^1.0.7",
 				"@npmcli/promise-spawn": "^3.0.0",
-				"@npmcli/run-script": "^3.0.1",
+				"@npmcli/run-script": "^4.1.0",
 				"cacache": "^16.0.0",
 				"chownr": "^2.0.0",
 				"fs-minipass": "^2.1.0",
@@ -3703,6 +3921,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm/node_modules/postcss-selector-parser": {
+			"version": "6.0.10",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
@@ -3781,14 +4011,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json": {
-			"version": "5.0.1",
+			"version": "5.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"glob": "^8.0.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"normalize-package-data": "^4.0.0",
-				"npm-normalize-package-bin": "^1.0.1"
+				"npm-normalize-package-bin": "^2.0.0"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -3804,6 +4034,14 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/readable-stream": {
@@ -3961,11 +4199,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.6.2",
+			"version": "2.7.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip": "^1.1.5",
+				"ip": "^2.0.0",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -3974,7 +4212,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
-			"version": "6.2.0",
+			"version": "7.0.0",
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4103,19 +4341,25 @@
 			}
 		},
 		"node_modules/npm/node_modules/unique-filename": {
-			"version": "1.1.1",
+			"version": "2.0.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"unique-slug": "^2.0.0"
+				"unique-slug": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/unique-slug": {
-			"version": "2.0.2",
+			"version": "3.0.0",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -4184,7 +4428,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4192,7 +4436,7 @@
 				"signal-exit": "^3.0.7"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
@@ -4630,11 +4874,11 @@
 			}
 		},
 		"node_modules/registry-auth-token": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
 			"dependencies": {
-				"rc": "^1.2.8"
+				"rc": "1.2.8"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -4649,11 +4893,11 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"dependencies": {
-				"is-core-module": "^2.8.1",
+				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -4731,9 +4975,9 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/semantic-release": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
-			"integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+			"integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^9.0.2",
 				"@semantic-release/error": "^3.0.0",
@@ -4964,9 +5208,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
 		},
 		"node_modules/split": {
 			"version": "1.0.1",
@@ -5195,12 +5439,12 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
 		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
@@ -5230,9 +5474,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5243,9 +5487,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
-			"integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -5286,7 +5530,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
@@ -5308,12 +5552,12 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -5336,7 +5580,7 @@
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
@@ -5357,7 +5601,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -5457,24 +5701,24 @@
 			"integrity": "sha512-d+RwPlMp+2qmBfeLYPLXuSRykDIFEwdTA0MMxzS9kh4kvP1ftrc/9fzy6pX6qAjthdXruHQ6/6kjT/DNo5ALuw=="
 		},
 		"@babel/code-frame": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"requires": {
-				"@babel/highlight": "^7.16.7"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
 		},
 		"@babel/highlight": {
-			"version": "7.17.12",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-			"integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -5597,16 +5841,16 @@
 			}
 		},
 		"@octokit/openapi-types": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-			"integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+			"version": "12.11.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+			"integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
 		},
 		"@octokit/plugin-paginate-rest": {
-			"version": "2.17.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-			"integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+			"version": "2.21.3",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+			"integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
 			"requires": {
-				"@octokit/types": "^6.34.0"
+				"@octokit/types": "^6.40.0"
 			}
 		},
 		"@octokit/plugin-request-log": {
@@ -5616,11 +5860,11 @@
 			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-			"integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+			"version": "5.16.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+			"integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
 			"requires": {
-				"@octokit/types": "^6.34.0",
+				"@octokit/types": "^6.39.0",
 				"deprecation": "^2.3.1"
 			}
 		},
@@ -5648,22 +5892,119 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "18.12.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-			"integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
+			"version": "19.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
+			"integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
 			"requires": {
-				"@octokit/core": "^3.5.1",
-				"@octokit/plugin-paginate-rest": "^2.16.8",
+				"@octokit/core": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^4.0.0",
 				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+				"@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+			},
+			"dependencies": {
+				"@octokit/auth-token": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
+					"integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+					"requires": {
+						"@octokit/types": "^7.0.0"
+					}
+				},
+				"@octokit/core": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
+					"integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+					"requires": {
+						"@octokit/auth-token": "^3.0.0",
+						"@octokit/graphql": "^5.0.0",
+						"@octokit/request": "^6.0.0",
+						"@octokit/request-error": "^3.0.0",
+						"@octokit/types": "^7.0.0",
+						"before-after-hook": "^2.2.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/endpoint": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
+					"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+					"requires": {
+						"@octokit/types": "^7.0.0",
+						"is-plain-object": "^5.0.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/graphql": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
+					"integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+					"requires": {
+						"@octokit/request": "^6.0.0",
+						"@octokit/types": "^7.0.0",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/openapi-types": {
+					"version": "13.6.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.6.0.tgz",
+					"integrity": "sha512-bxftLwoZ2J6zsU1rzRvk0O32j7lVB0NWWn+P5CDHn9zPzytasR3hdAeXlTngRDkqv1LyEeuy5psVnDkmOSwrcQ=="
+				},
+				"@octokit/plugin-paginate-rest": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.0.tgz",
+					"integrity": "sha512-8otLCIK9esfmOCY14CBnG/xPqv0paf14rc+s9tHpbOpeFwrv5CnECKW1qdqMAT60ngAa9eB1bKQ+l2YCpi0HPQ==",
+					"requires": {
+						"@octokit/types": "^7.2.0"
+					}
+				},
+				"@octokit/plugin-rest-endpoint-methods": {
+					"version": "6.4.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.4.0.tgz",
+					"integrity": "sha512-YP4eUqZ6vORy/eZOTdil1ZSrMt0kv7i/CVw+HhC2C0yJN+IqTc/rot957JQ7JfyeJD6HZOjLg6Jp1o9cPhI9KA==",
+					"requires": {
+						"@octokit/types": "^7.2.0",
+						"deprecation": "^2.3.1"
+					}
+				},
+				"@octokit/request": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
+					"integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+					"requires": {
+						"@octokit/endpoint": "^7.0.0",
+						"@octokit/request-error": "^3.0.0",
+						"@octokit/types": "^7.0.0",
+						"is-plain-object": "^5.0.0",
+						"node-fetch": "^2.6.7",
+						"universal-user-agent": "^6.0.0"
+					}
+				},
+				"@octokit/request-error": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
+					"integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+					"requires": {
+						"@octokit/types": "^7.0.0",
+						"deprecation": "^2.0.0",
+						"once": "^1.4.0"
+					}
+				},
+				"@octokit/types": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.2.0.tgz",
+					"integrity": "sha512-pYQ/a1U6mHptwhGyp6SvsiM4bWP2s3V95olUeTxas85D/2kN78yN5C8cGN+P4LwJSWUqIEyvq0Qn2WUn6NQRjw==",
+					"requires": {
+						"@octokit/openapi-types": "^13.6.0"
+					}
+				}
 			}
 		},
 		"@octokit/types": {
-			"version": "6.34.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-			"integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
 			"requires": {
-				"@octokit/openapi-types": "^11.2.0"
+				"@octokit/openapi-types": "^12.11.0"
 			}
 		},
 		"@semantic-release/commit-analyzer": {
@@ -5686,12 +6027,12 @@
 			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
 		},
 		"@semantic-release/github": {
-			"version": "8.0.4",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
-			"integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
+			"version": "8.0.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
+			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
 			"requires": {
-				"@octokit/rest": "^18.0.0",
-				"@semantic-release/error": "^2.2.0",
+				"@octokit/rest": "^19.0.0",
+				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
@@ -5706,13 +6047,6 @@
 				"p-filter": "^2.0.0",
 				"p-retry": "^4.0.0",
 				"url-join": "^4.0.0"
-			},
-			"dependencies": {
-				"@semantic-release/error": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-					"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
-				}
 			}
 		},
 		"@semantic-release/npm": {
@@ -5763,9 +6097,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.0.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.1.tgz",
-			"integrity": "sha512-CmR8+Tsy95hhwtZBKJBs0/FFq4XX7sDZHlGGf+0q+BRZfMbOTkzkj0AFAuTyXbObDIoanaBBW0+KEW+m3N16Wg==",
+			"version": "18.7.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6496,9 +6830,9 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"is-core-module": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-			"integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
+			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -6723,9 +7057,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
-			"integrity": "sha512-wahonIQ5Jnyatt2fn8KqF/nIqZM8mh3oRu2+l5EANGMhu6RFjiSG52QNE2eWzFMI94HqYSgN184NurgNG6CztA=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
+			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -6875,68 +7209,72 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.12.1.tgz",
-			"integrity": "sha512-0yOlhfgu1UzP6UijnaFuIS2bES2H9D90EA5OVsf2iOZw7VBrjntXKEwKfCaFA6vMVWkCP8qnPwCxxPdnDVwlNw==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.0.tgz",
+			"integrity": "sha512-Af+oxQyq+ZY0M3ygaXs4T4DVbN8HU0XjLMK9ghXLh48u16OQoEYXazx8miUM2h1qLMgTuEwhhuVlCNDkKLOcmg==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.0.4",
+				"@npmcli/arborist": "^5.6.1",
 				"@npmcli/ci-detect": "^2.0.0",
-				"@npmcli/config": "^4.1.0",
+				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/run-script": "^3.0.1",
+				"@npmcli/promise-spawn": "*",
+				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
-				"cacache": "^16.1.0",
+				"cacache": "^16.1.3",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^4.0.0",
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
+				"fs-minipass": "*",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.0.0",
-				"ini": "^3.0.0",
+				"hosted-git-info": "^5.1.0",
+				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
-				"libnpmaccess": "^6.0.2",
-				"libnpmdiff": "^4.0.2",
-				"libnpmexec": "^4.0.2",
-				"libnpmfund": "^3.0.1",
-				"libnpmhook": "^8.0.2",
-				"libnpmorg": "^4.0.2",
-				"libnpmpack": "^4.0.2",
-				"libnpmpublish": "^6.0.2",
-				"libnpmsearch": "^5.0.2",
-				"libnpmteam": "^4.0.2",
-				"libnpmversion": "^3.0.1",
-				"make-fetch-happen": "^10.1.6",
+				"libnpmaccess": "^6.0.4",
+				"libnpmdiff": "^4.0.5",
+				"libnpmexec": "^4.0.12",
+				"libnpmfund": "^3.0.3",
+				"libnpmhook": "^8.0.4",
+				"libnpmorg": "^4.0.4",
+				"libnpmpack": "^4.1.3",
+				"libnpmpublish": "^6.0.5",
+				"libnpmsearch": "^5.0.4",
+				"libnpmteam": "^4.0.4",
+				"libnpmversion": "^3.0.7",
+				"make-fetch-happen": "^10.2.0",
+				"minimatch": "*",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
 				"mkdirp-infer-owner": "^2.0.0",
 				"ms": "^2.1.2",
-				"node-gyp": "^9.0.0",
-				"nopt": "^5.0.0",
+				"node-gyp": "^9.1.0",
+				"nopt": "^6.0.0",
 				"npm-audit-report": "^3.0.0",
 				"npm-install-checks": "^5.0.0",
-				"npm-package-arg": "^9.0.2",
-				"npm-pick-manifest": "^7.0.1",
-				"npm-profile": "^6.0.3",
-				"npm-registry-fetch": "^13.1.1",
+				"npm-package-arg": "^9.1.0",
+				"npm-pick-manifest": "^7.0.2",
+				"npm-profile": "^6.2.0",
+				"npm-registry-fetch": "^13.3.1",
 				"npm-user-validate": "^1.0.1",
 				"npmlog": "^6.0.2",
 				"opener": "^1.5.2",
-				"pacote": "^13.6.0",
+				"p-map": "^4.0.0",
+				"pacote": "^13.6.2",
 				"parse-conflict-json": "^2.0.2",
 				"proc-log": "^2.0.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^5.0.1",
+				"read-package-json": "^5.0.2",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
@@ -6965,7 +7303,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.2.1",
+					"version": "5.6.1",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -6976,21 +7314,23 @@
 						"@npmcli/name-from-folder": "^1.0.1",
 						"@npmcli/node-gyp": "^2.0.0",
 						"@npmcli/package-json": "^2.0.0",
-						"@npmcli/run-script": "^3.0.0",
-						"bin-links": "^3.0.0",
-						"cacache": "^16.0.6",
+						"@npmcli/query": "^1.2.0",
+						"@npmcli/run-script": "^4.1.3",
+						"bin-links": "^3.0.3",
+						"cacache": "^16.1.3",
 						"common-ancestor-path": "^1.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"json-stringify-nice": "^1.1.4",
+						"minimatch": "^5.1.0",
 						"mkdirp": "^1.0.4",
 						"mkdirp-infer-owner": "^2.0.0",
-						"nopt": "^5.0.0",
+						"nopt": "^6.0.0",
 						"npm-install-checks": "^5.0.0",
 						"npm-package-arg": "^9.0.0",
-						"npm-pick-manifest": "^7.0.0",
+						"npm-pick-manifest": "^7.0.2",
 						"npm-registry-fetch": "^13.0.0",
 						"npmlog": "^6.0.2",
-						"pacote": "^13.0.5",
+						"pacote": "^13.6.1",
 						"parse-conflict-json": "^2.0.1",
 						"proc-log": "^2.0.0",
 						"promise-all-reject-late": "^1.0.0",
@@ -7009,13 +7349,13 @@
 					"bundled": true
 				},
 				"@npmcli/config": {
-					"version": "4.1.0",
+					"version": "4.2.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/map-workspaces": "^2.0.2",
 						"ini": "^3.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
-						"nopt": "^5.0.0",
+						"nopt": "^6.0.0",
 						"proc-log": "^2.0.0",
 						"read-package-json-fast": "^2.0.3",
 						"semver": "^7.3.5",
@@ -7030,7 +7370,7 @@
 					}
 				},
 				"@npmcli/fs": {
-					"version": "2.1.0",
+					"version": "2.1.2",
 					"bundled": true,
 					"requires": {
 						"@gar/promisify": "^1.1.3",
@@ -7038,7 +7378,7 @@
 					}
 				},
 				"@npmcli/git": {
-					"version": "3.0.1",
+					"version": "3.0.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/promise-spawn": "^3.0.0",
@@ -7058,10 +7398,19 @@
 					"requires": {
 						"npm-bundled": "^1.1.1",
 						"npm-normalize-package-bin": "^1.0.1"
+					},
+					"dependencies": {
+						"npm-bundled": {
+							"version": "1.1.2",
+							"bundled": true,
+							"requires": {
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						}
 					}
 				},
 				"@npmcli/map-workspaces": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"requires": {
 						"@npmcli/name-from-folder": "^1.0.1",
@@ -7071,7 +7420,7 @@
 					}
 				},
 				"@npmcli/metavuln-calculator": {
-					"version": "3.1.0",
+					"version": "3.1.1",
 					"bundled": true,
 					"requires": {
 						"cacache": "^16.0.0",
@@ -7081,7 +7430,7 @@
 					}
 				},
 				"@npmcli/move-file": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
 						"mkdirp": "^1.0.4",
@@ -7110,14 +7459,24 @@
 						"infer-owner": "^1.0.4"
 					}
 				},
+				"@npmcli/query": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"npm-package-arg": "^9.1.0",
+						"postcss-selector-parser": "^6.0.10",
+						"semver": "^7.3.7"
+					}
+				},
 				"@npmcli/run-script": {
-					"version": "3.0.2",
+					"version": "4.2.1",
 					"bundled": true,
 					"requires": {
 						"@npmcli/node-gyp": "^2.0.0",
 						"@npmcli/promise-spawn": "^3.0.0",
 						"node-gyp": "^9.0.0",
-						"read-package-json-fast": "^2.0.3"
+						"read-package-json-fast": "^2.0.3",
+						"which": "^2.0.2"
 					}
 				},
 				"@tootallnate/once": {
@@ -7172,7 +7531,7 @@
 					"bundled": true
 				},
 				"are-we-there-yet": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -7188,15 +7547,21 @@
 					"bundled": true
 				},
 				"bin-links": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
 						"cmd-shim": "^5.0.0",
 						"mkdirp-infer-owner": "^2.0.0",
-						"npm-normalize-package-bin": "^1.0.0",
+						"npm-normalize-package-bin": "^2.0.0",
 						"read-cmd-shim": "^3.0.0",
 						"rimraf": "^3.0.0",
 						"write-file-atomic": "^4.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true
+						}
 					}
 				},
 				"binary-extensions": {
@@ -7218,7 +7583,7 @@
 					}
 				},
 				"cacache": {
-					"version": "16.1.0",
+					"version": "16.1.3",
 					"bundled": true,
 					"requires": {
 						"@npmcli/fs": "^2.1.0",
@@ -7238,7 +7603,7 @@
 						"rimraf": "^3.0.2",
 						"ssri": "^9.0.0",
 						"tar": "^6.1.11",
-						"unique-filename": "^1.1.1"
+						"unique-filename": "^2.0.0"
 					}
 				},
 				"chalk": {
@@ -7326,6 +7691,10 @@
 					"version": "1.1.0",
 					"bundled": true
 				},
+				"cssesc": {
+					"version": "3.0.0",
+					"bundled": true
+				},
 				"debug": {
 					"version": "4.3.4",
 					"bundled": true,
@@ -7367,7 +7736,7 @@
 					}
 				},
 				"diff": {
-					"version": "5.0.0",
+					"version": "5.1.0",
 					"bundled": true
 				},
 				"emoji-regex": {
@@ -7454,7 +7823,7 @@
 					"bundled": true
 				},
 				"hosted-git-info": {
-					"version": "5.0.0",
+					"version": "5.1.0",
 					"bundled": true,
 					"requires": {
 						"lru-cache": "^7.5.1"
@@ -7528,7 +7897,7 @@
 					"bundled": true
 				},
 				"ini": {
-					"version": "3.0.0",
+					"version": "3.0.1",
 					"bundled": true
 				},
 				"init-package-json": {
@@ -7545,7 +7914,7 @@
 					}
 				},
 				"ip": {
-					"version": "1.1.8",
+					"version": "2.0.0",
 					"bundled": true
 				},
 				"ip-regex": {
@@ -7560,7 +7929,7 @@
 					}
 				},
 				"is-core-module": {
-					"version": "2.9.0",
+					"version": "2.10.0",
 					"bundled": true,
 					"requires": {
 						"has": "^1.0.3"
@@ -7591,15 +7960,15 @@
 					"bundled": true
 				},
 				"just-diff": {
-					"version": "5.0.2",
+					"version": "5.1.1",
 					"bundled": true
 				},
 				"just-diff-apply": {
-					"version": "5.2.0",
+					"version": "5.4.1",
 					"bundled": true
 				},
 				"libnpmaccess": {
-					"version": "6.0.3",
+					"version": "6.0.4",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7609,46 +7978,48 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "4.0.3",
+					"version": "4.0.5",
 					"bundled": true,
 					"requires": {
 						"@npmcli/disparity-colors": "^2.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"binary-extensions": "^2.2.0",
-						"diff": "^5.0.0",
+						"diff": "^5.1.0",
 						"minimatch": "^5.0.1",
 						"npm-package-arg": "^9.0.1",
-						"pacote": "^13.0.5",
+						"pacote": "^13.6.1",
 						"tar": "^6.1.0"
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.6",
+					"version": "4.0.12",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.0.0",
+						"@npmcli/arborist": "^5.6.1",
 						"@npmcli/ci-detect": "^2.0.0",
-						"@npmcli/run-script": "^3.0.0",
+						"@npmcli/fs": "^2.1.1",
+						"@npmcli/run-script": "^4.2.0",
 						"chalk": "^4.1.0",
 						"mkdirp-infer-owner": "^2.0.0",
 						"npm-package-arg": "^9.0.1",
 						"npmlog": "^6.0.2",
-						"pacote": "^13.0.5",
+						"pacote": "^13.6.1",
 						"proc-log": "^2.0.0",
 						"read": "^1.0.7",
 						"read-package-json-fast": "^2.0.2",
+						"semver": "^7.3.7",
 						"walk-up-path": "^1.0.0"
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.0.0"
+						"@npmcli/arborist": "^5.6.1"
 					}
 				},
 				"libnpmhook": {
-					"version": "8.0.3",
+					"version": "8.0.4",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7656,7 +8027,7 @@
 					}
 				},
 				"libnpmorg": {
-					"version": "4.0.3",
+					"version": "4.0.4",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7664,16 +8035,16 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "4.1.0",
+					"version": "4.1.3",
 					"bundled": true,
 					"requires": {
-						"@npmcli/run-script": "^3.0.0",
+						"@npmcli/run-script": "^4.1.3",
 						"npm-package-arg": "^9.0.1",
-						"pacote": "^13.5.0"
+						"pacote": "^13.6.1"
 					}
 				},
 				"libnpmpublish": {
-					"version": "6.0.4",
+					"version": "6.0.5",
 					"bundled": true,
 					"requires": {
 						"normalize-package-data": "^4.0.0",
@@ -7684,14 +8055,14 @@
 					}
 				},
 				"libnpmsearch": {
-					"version": "5.0.3",
+					"version": "5.0.4",
 					"bundled": true,
 					"requires": {
 						"npm-registry-fetch": "^13.0.0"
 					}
 				},
 				"libnpmteam": {
-					"version": "4.0.3",
+					"version": "4.0.4",
 					"bundled": true,
 					"requires": {
 						"aproba": "^2.0.0",
@@ -7699,22 +8070,22 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "3.0.4",
+					"version": "3.0.7",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
-						"@npmcli/run-script": "^3.0.0",
+						"@npmcli/run-script": "^4.1.3",
 						"json-parse-even-better-errors": "^2.3.1",
 						"proc-log": "^2.0.0",
 						"semver": "^7.3.7"
 					}
 				},
 				"lru-cache": {
-					"version": "7.9.0",
+					"version": "7.13.2",
 					"bundled": true
 				},
 				"make-fetch-happen": {
-					"version": "10.1.6",
+					"version": "10.2.1",
 					"bundled": true,
 					"requires": {
 						"agentkeepalive": "^4.2.1",
@@ -7731,7 +8102,7 @@
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.3",
 						"promise-retry": "^2.0.1",
-						"socks-proxy-agent": "^6.1.1",
+						"socks-proxy-agent": "^7.0.0",
 						"ssri": "^9.0.0"
 					}
 				},
@@ -7743,7 +8114,7 @@
 					}
 				},
 				"minipass": {
-					"version": "3.1.6",
+					"version": "3.3.4",
 					"bundled": true,
 					"requires": {
 						"yallist": "^4.0.0"
@@ -7757,7 +8128,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "2.1.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"requires": {
 						"encoding": "^0.1.13",
@@ -7829,7 +8200,7 @@
 					"bundled": true
 				},
 				"node-gyp": {
-					"version": "9.0.0",
+					"version": "9.1.0",
 					"bundled": true,
 					"requires": {
 						"env-paths": "^2.2.0",
@@ -7870,18 +8241,25 @@
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
+						},
+						"nopt": {
+							"version": "5.0.0",
+							"bundled": true,
+							"requires": {
+								"abbrev": "1"
+							}
 						}
 					}
 				},
 				"nopt": {
-					"version": "5.0.0",
+					"version": "6.0.0",
 					"bundled": true,
 					"requires": {
-						"abbrev": "1"
+						"abbrev": "^1.0.0"
 					}
 				},
 				"normalize-package-data": {
-					"version": "4.0.0",
+					"version": "4.0.1",
 					"bundled": true,
 					"requires": {
 						"hosted-git-info": "^5.0.0",
@@ -7898,10 +8276,16 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.1.2",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true
+						}
 					}
 				},
 				"npm-install-checks": {
@@ -7916,36 +8300,49 @@
 					"bundled": true
 				},
 				"npm-package-arg": {
-					"version": "9.0.2",
+					"version": "9.1.0",
 					"bundled": true,
 					"requires": {
 						"hosted-git-info": "^5.0.0",
+						"proc-log": "^2.0.1",
 						"semver": "^7.3.5",
 						"validate-npm-package-name": "^4.0.0"
 					}
 				},
 				"npm-packlist": {
-					"version": "5.1.0",
+					"version": "5.1.3",
 					"bundled": true,
 					"requires": {
 						"glob": "^8.0.1",
 						"ignore-walk": "^5.0.1",
-						"npm-bundled": "^1.1.2",
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-bundled": "^2.0.0",
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true
+						}
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "7.0.1",
+					"version": "7.0.2",
 					"bundled": true,
 					"requires": {
 						"npm-install-checks": "^5.0.0",
-						"npm-normalize-package-bin": "^1.0.1",
+						"npm-normalize-package-bin": "^2.0.0",
 						"npm-package-arg": "^9.0.0",
 						"semver": "^7.3.5"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true
+						}
 					}
 				},
 				"npm-profile": {
-					"version": "6.0.3",
+					"version": "6.2.1",
 					"bundled": true,
 					"requires": {
 						"npm-registry-fetch": "^13.0.1",
@@ -7953,7 +8350,7 @@
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "13.1.1",
+					"version": "13.3.1",
 					"bundled": true,
 					"requires": {
 						"make-fetch-happen": "^10.0.6",
@@ -7998,13 +8395,13 @@
 					}
 				},
 				"pacote": {
-					"version": "13.6.0",
+					"version": "13.6.2",
 					"bundled": true,
 					"requires": {
 						"@npmcli/git": "^3.0.0",
 						"@npmcli/installed-package-contents": "^1.0.7",
 						"@npmcli/promise-spawn": "^3.0.0",
-						"@npmcli/run-script": "^3.0.1",
+						"@npmcli/run-script": "^4.1.0",
 						"cacache": "^16.0.0",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.1.0",
@@ -8036,6 +8433,14 @@
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.10",
+					"bundled": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"util-deprecate": "^1.0.2"
+					}
 				},
 				"proc-log": {
 					"version": "2.0.1",
@@ -8084,13 +8489,19 @@
 					"bundled": true
 				},
 				"read-package-json": {
-					"version": "5.0.1",
+					"version": "5.0.2",
 					"bundled": true,
 					"requires": {
 						"glob": "^8.0.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"normalize-package-data": "^4.0.0",
-						"npm-normalize-package-bin": "^1.0.1"
+						"npm-normalize-package-bin": "^2.0.0"
+					},
+					"dependencies": {
+						"npm-normalize-package-bin": {
+							"version": "2.0.0",
+							"bundled": true
+						}
 					}
 				},
 				"read-package-json-fast": {
@@ -8198,15 +8609,15 @@
 					"bundled": true
 				},
 				"socks": {
-					"version": "2.6.2",
+					"version": "2.7.0",
 					"bundled": true,
 					"requires": {
-						"ip": "^1.1.5",
+						"ip": "^2.0.0",
 						"smart-buffer": "^4.2.0"
 					}
 				},
 				"socks-proxy-agent": {
-					"version": "6.2.0",
+					"version": "7.0.0",
 					"bundled": true,
 					"requires": {
 						"agent-base": "^6.0.2",
@@ -8300,14 +8711,14 @@
 					"bundled": true
 				},
 				"unique-filename": {
-					"version": "1.1.1",
+					"version": "2.0.1",
 					"bundled": true,
 					"requires": {
-						"unique-slug": "^2.0.0"
+						"unique-slug": "^3.0.0"
 					}
 				},
 				"unique-slug": {
-					"version": "2.0.2",
+					"version": "3.0.0",
 					"bundled": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -8362,7 +8773,7 @@
 					"bundled": true
 				},
 				"write-file-atomic": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"requires": {
 						"imurmurhash": "^0.1.4",
@@ -8684,11 +9095,11 @@
 			}
 		},
 		"registry-auth-token": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
-			"integrity": "sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
+			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
 			"requires": {
-				"rc": "^1.2.8"
+				"rc": "1.2.8"
 			}
 		},
 		"require-directory": {
@@ -8697,11 +9108,11 @@
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
 		},
 		"resolve": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+			"version": "1.22.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
 			"requires": {
-				"is-core-module": "^2.8.1",
+				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
@@ -8743,9 +9154,9 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"semantic-release": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.3.tgz",
-			"integrity": "sha512-HaFbydST1cDKZHuFZxB8DTrBLJVK/AnDExpK0s3EqLIAAUAHUgnd+VSJCUtTYQKkAkauL8G9CucODrVCc7BuAA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
+			"integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
 			"requires": {
 				"@semantic-release/commit-analyzer": "^9.0.2",
 				"@semantic-release/error": "^3.0.0",
@@ -8926,9 +9337,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA=="
 		},
 		"split": {
 			"version": "1.0.1",
@@ -9103,12 +9514,12 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
 		},
 		"trim-newlines": {
 			"version": "3.0.1",
@@ -9126,15 +9537,15 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.0.tgz",
-			"integrity": "sha512-FEikl6bR30n0T3amyBh3LoiBdqHRy/f4H80+My34HOesOKyHfOsxAPAxOoqC0JUnC1amnO0IwkYC3sko51caSw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"optional": true
 		},
 		"unique-string": {
@@ -9163,7 +9574,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"uuid": {
 			"version": "8.3.2",
@@ -9182,12 +9593,12 @@
 		"webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
 		},
 		"whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
 			"requires": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -9204,7 +9615,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
@@ -9219,7 +9630,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"xtend": {
 			"version": "4.0.2",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._