### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,9 +71,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -332,9 +332,9 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-			"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+			"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 			"dependencies": {
 				"@octokit/types": "^7.0.0",
 				"is-plain-object": "^5.0.0",
@@ -358,16 +358,16 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
-			"version": "13.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.6.0.tgz",
-			"integrity": "sha512-bxftLwoZ2J6zsU1rzRvk0O32j7lVB0NWWn+P5CDHn9zPzytasR3hdAeXlTngRDkqv1LyEeuy5psVnDkmOSwrcQ=="
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
+			"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA=="
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.0.tgz",
-			"integrity": "sha512-8otLCIK9esfmOCY14CBnG/xPqv0paf14rc+s9tHpbOpeFwrv5CnECKW1qdqMAT60ngAa9eB1bKQ+l2YCpi0HPQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
+			"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
 			"dependencies": {
-				"@octokit/types": "^7.2.0"
+				"@octokit/types": "^7.4.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -377,11 +377,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.4.0.tgz",
-			"integrity": "sha512-YP4eUqZ6vORy/eZOTdil1ZSrMt0kv7i/CVw+HhC2C0yJN+IqTc/rot957JQ7JfyeJD6HZOjLg6Jp1o9cPhI9KA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
+			"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
 			"dependencies": {
-				"@octokit/types": "^7.2.0",
+				"@octokit/types": "^7.4.0",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -421,11 +421,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/types": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.2.0.tgz",
-			"integrity": "sha512-pYQ/a1U6mHptwhGyp6SvsiM4bWP2s3V95olUeTxas85D/2kN78yN5C8cGN+P4LwJSWUqIEyvq0Qn2WUn6NQRjw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
 			"dependencies": {
-				"@octokit/openapi-types": "^13.6.0"
+				"@octokit/openapi-types": "^13.10.0"
 			}
 		},
 		"node_modules/@octokit/types": {
@@ -556,9 +556,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
-			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -1139,9 +1139,9 @@
 			}
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -2078,9 +2078,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.0.tgz",
-			"integrity": "sha512-Af+oxQyq+ZY0M3ygaXs4T4DVbN8HU0XjLMK9ghXLh48u16OQoEYXazx8miUM2h1qLMgTuEwhhuVlCNDkKLOcmg==",
+			"version": "8.19.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
+			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2159,7 +2159,7 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.6.1",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
@@ -2186,8 +2186,8 @@
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.4",
 				"libnpmdiff": "^4.0.5",
-				"libnpmexec": "^4.0.12",
-				"libnpmfund": "^3.0.3",
+				"libnpmexec": "^4.0.13",
+				"libnpmfund": "^3.0.4",
 				"libnpmhook": "^8.0.4",
 				"libnpmorg": "^4.0.4",
 				"libnpmpack": "^4.1.3",
@@ -2272,7 +2272,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.6.1",
+			"version": "5.6.2",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3276,11 +3276,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.12",
+			"version": "4.0.13",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.6.1",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/fs": "^2.1.1",
 				"@npmcli/run-script": "^4.2.0",
@@ -3300,11 +3300,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.3",
+			"version": "3.0.4",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.6.1"
+				"@npmcli/arborist": "^5.6.2"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -5332,9 +5332,9 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"dependencies": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
@@ -5474,9 +5474,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5709,9 +5709,9 @@
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
 		},
 		"@babel/highlight": {
 			"version": "7.18.6",
@@ -5925,9 +5925,9 @@
 					}
 				},
 				"@octokit/endpoint": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
-					"integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
+					"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
 					"requires": {
 						"@octokit/types": "^7.0.0",
 						"is-plain-object": "^5.0.0",
@@ -5945,24 +5945,24 @@
 					}
 				},
 				"@octokit/openapi-types": {
-					"version": "13.6.0",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.6.0.tgz",
-					"integrity": "sha512-bxftLwoZ2J6zsU1rzRvk0O32j7lVB0NWWn+P5CDHn9zPzytasR3hdAeXlTngRDkqv1LyEeuy5psVnDkmOSwrcQ=="
+					"version": "13.10.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
+					"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA=="
 				},
 				"@octokit/plugin-paginate-rest": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.2.0.tgz",
-					"integrity": "sha512-8otLCIK9esfmOCY14CBnG/xPqv0paf14rc+s9tHpbOpeFwrv5CnECKW1qdqMAT60ngAa9eB1bKQ+l2YCpi0HPQ==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
+					"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
 					"requires": {
-						"@octokit/types": "^7.2.0"
+						"@octokit/types": "^7.4.0"
 					}
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.4.0.tgz",
-					"integrity": "sha512-YP4eUqZ6vORy/eZOTdil1ZSrMt0kv7i/CVw+HhC2C0yJN+IqTc/rot957JQ7JfyeJD6HZOjLg6Jp1o9cPhI9KA==",
+					"version": "6.6.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
+					"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
 					"requires": {
-						"@octokit/types": "^7.2.0",
+						"@octokit/types": "^7.4.0",
 						"deprecation": "^2.3.1"
 					}
 				},
@@ -5990,11 +5990,11 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.2.0.tgz",
-					"integrity": "sha512-pYQ/a1U6mHptwhGyp6SvsiM4bWP2s3V95olUeTxas85D/2kN78yN5C8cGN+P4LwJSWUqIEyvq0Qn2WUn6NQRjw==",
+					"version": "7.4.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
+					"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
 					"requires": {
-						"@octokit/openapi-types": "^13.6.0"
+						"@octokit/openapi-types": "^13.10.0"
 					}
 				}
 			}
@@ -6097,9 +6097,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.7.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
-			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
+			"version": "18.7.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.18.tgz",
+			"integrity": "sha512-m+6nTEOadJZuTPkKR/SYK3A2d7FZrgElol9UP1Kae90VVU4a6mxnPuLiIW1m4Cq4gZ/nWb9GrdVXJCoCazDAbg==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6531,9 +6531,9 @@
 			}
 		},
 		"fast-glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"version": "3.2.12",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -7209,12 +7209,12 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.0.tgz",
-			"integrity": "sha512-Af+oxQyq+ZY0M3ygaXs4T4DVbN8HU0XjLMK9ghXLh48u16OQoEYXazx8miUM2h1qLMgTuEwhhuVlCNDkKLOcmg==",
+			"version": "8.19.2",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
+			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.6.1",
+				"@npmcli/arborist": "^5.6.2",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
@@ -7241,8 +7241,8 @@
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.4",
 				"libnpmdiff": "^4.0.5",
-				"libnpmexec": "^4.0.12",
-				"libnpmfund": "^3.0.3",
+				"libnpmexec": "^4.0.13",
+				"libnpmfund": "^3.0.4",
 				"libnpmhook": "^8.0.4",
 				"libnpmorg": "^4.0.4",
 				"libnpmpack": "^4.1.3",
@@ -7303,7 +7303,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.6.1",
+					"version": "5.6.2",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -7992,10 +7992,10 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.12",
+					"version": "4.0.13",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.6.1",
+						"@npmcli/arborist": "^5.6.2",
 						"@npmcli/ci-detect": "^2.0.0",
 						"@npmcli/fs": "^2.1.1",
 						"@npmcli/run-script": "^4.2.0",
@@ -8012,10 +8012,10 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.3",
+					"version": "3.0.4",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.6.1"
+						"@npmcli/arborist": "^5.6.2"
 					}
 				},
 				"libnpmhook": {
@@ -9436,9 +9436,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-			"integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
 			"requires": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
@@ -9537,9 +9537,9 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-			"integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+			"version": "4.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
 			"dev": true
 		},
 		"uglify-js": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._