### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
@@ -36,9 +36,9 @@
 			}
 		},
 		"node_modules/@actions/github": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
-			"integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+			"integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"@octokit/core": "^3.6.0",
@@ -358,16 +358,16 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
-			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
-			"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA=="
+			"version": "13.13.1",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
+			"integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
-			"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
+			"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
 			"dependencies": {
-				"@octokit/types": "^7.4.0"
+				"@octokit/types": "^7.5.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -377,11 +377,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
-			"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
+			"version": "6.6.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
+			"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
 			"dependencies": {
-				"@octokit/types": "^7.4.0",
+				"@octokit/types": "^7.5.0",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -421,11 +421,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/types": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
-			"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
+			"integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
 			"dependencies": {
-				"@octokit/openapi-types": "^13.10.0"
+				"@octokit/openapi-types": "^13.11.0"
 			}
 		},
 		"node_modules/@octokit/types": {
@@ -556,9 +556,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.7.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
+			"version": "18.8.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -672,9 +672,9 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/before-after-hook": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
 		},
 		"node_modules/bottleneck": {
 			"version": "2.19.5",
@@ -746,9 +746,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
+			"integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ==",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -765,9 +765,9 @@
 			}
 		},
 		"node_modules/cli-table3": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
 			"dependencies": {
 				"string-width": "^4.2.0"
 			},
@@ -1857,9 +1857,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+			"integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -5016,9 +5016,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -5474,9 +5474,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5487,9 +5487,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
-			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
+			"integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -5660,9 +5660,9 @@
 	},
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"requires": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
@@ -5677,9 +5677,9 @@
 			}
 		},
 		"@actions/github": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.3.tgz",
-			"integrity": "sha512-myjA/pdLQfhUGLtRZC/J4L1RXOG4o6aYdiEq+zr5wVVKljzbFld+xv10k1FX6IkIJtNxbAq44BdwSNpQ015P0A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+			"integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
 			"requires": {
 				"@actions/http-client": "^2.0.1",
 				"@octokit/core": "^3.6.0",
@@ -5945,24 +5945,24 @@
 					}
 				},
 				"@octokit/openapi-types": {
-					"version": "13.10.0",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.10.0.tgz",
-					"integrity": "sha512-wPQDpTyy35D6VS/lekXDaKcxy6LI2hzcbmXBnP180Pdgz3dXRzoHdav0w09yZzzWX8HHLGuqwAeyMqEPtWY2XA=="
+					"version": "13.13.1",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
+					"integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
 				},
 				"@octokit/plugin-paginate-rest": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.0.tgz",
-					"integrity": "sha512-4V8hWMoXuxb03xPs3s3RjUb5Bzx4HmVRhG+gvbO08PB48ag6G8mk6/HDFKlAXz9XEorDIkc0pXcXnaOz8spHgg==",
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
+					"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
 					"requires": {
-						"@octokit/types": "^7.4.0"
+						"@octokit/types": "^7.5.0"
 					}
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.0.tgz",
-					"integrity": "sha512-IAuT/e1gIUVszNmV+vfXNxa6xXI9dlghhBDqLGEmjz3so9sHqOlXN4R5gWcCRJkt4mum4NCaNjUk17yTrK76Rw==",
+					"version": "6.6.2",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
+					"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
 					"requires": {
-						"@octokit/types": "^7.4.0",
+						"@octokit/types": "^7.5.0",
 						"deprecation": "^2.3.1"
 					}
 				},
@@ -5990,11 +5990,11 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.4.0.tgz",
-					"integrity": "sha512-ln1GW0p72+P8qeRjHGj0wyR5ePy6slqvczveOqonMk1w1UWua6UgrkwFzv6S0vKWjSqt/ijYXF1ehNVRRRSvLA==",
+					"version": "7.5.1",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
+					"integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
 					"requires": {
-						"@octokit/openapi-types": "^13.10.0"
+						"@octokit/openapi-types": "^13.11.0"
 					}
 				}
 			}
@@ -6097,9 +6097,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.7.23",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-			"integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
+			"version": "18.8.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6186,9 +6186,9 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"before-after-hook": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-			"integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
 		},
 		"bottleneck": {
 			"version": "2.19.5",
@@ -6242,9 +6242,9 @@
 			}
 		},
 		"chalk": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
+			"integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -6252,9 +6252,9 @@
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
 		},
 		"cli-table3": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
-			"integrity": "sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
 			"requires": {
 				"@colors/colors": "1.5.0",
 				"string-width": "^4.2.0"
@@ -7057,9 +7057,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.0.tgz",
-			"integrity": "sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
+			"integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -9189,9 +9189,9 @@
 			}
 		},
 		"semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.3.8",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -9537,15 +9537,15 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-			"integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
-			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
+			"version": "3.17.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
+			"integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._