### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -290,40 +290,40 @@
 			}
 		},
 		"node_modules/@octokit/rest": {
-			"version": "19.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
-			"integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.5.tgz",
+			"integrity": "sha512-+4qdrUFq2lk7Va+Qff3ofREQWGBeoTKNqlJO+FGjFP35ZahP+nBenhZiGdu8USSgmq4Ky3IJ/i4u0xbLqHaeow==",
 			"dependencies": {
-				"@octokit/core": "^4.0.0",
-				"@octokit/plugin-paginate-rest": "^4.0.0",
+				"@octokit/core": "^4.1.0",
+				"@octokit/plugin-paginate-rest": "^5.0.0",
 				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+				"@octokit/plugin-rest-endpoint-methods": "^6.7.0"
 			},
 			"engines": {
 				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
-			"integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
+			"integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
 			"dependencies": {
-				"@octokit/types": "^7.0.0"
+				"@octokit/types": "^8.0.0"
 			},
 			"engines": {
 				"node": ">= 14"
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/core": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
-			"integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+			"integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
 			"dependencies": {
 				"@octokit/auth-token": "^3.0.0",
 				"@octokit/graphql": "^5.0.0",
 				"@octokit/request": "^6.0.0",
 				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^8.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -332,11 +332,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
-			"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.3.tgz",
+			"integrity": "sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==",
 			"dependencies": {
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^8.0.0",
 				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -345,12 +345,12 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
-			"integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.4.tgz",
+			"integrity": "sha512-amO1M5QUQgYQo09aStR/XO7KAl13xpigcy/kI8/N1PnZYSS69fgte+xA4+c2DISKqUZfsh0wwjc2FaCt99L41A==",
 			"dependencies": {
 				"@octokit/request": "^6.0.0",
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^8.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -358,16 +358,16 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
-			"version": "13.13.1",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
-			"integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+			"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
-			"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-5.0.1.tgz",
+			"integrity": "sha512-7A+rEkS70pH36Z6JivSlR7Zqepz3KVucEFVDnSrgHXzG7WLAzYwcHZbKdfTXHwuTHbkT1vKvz7dHl1+HNf6Qyw==",
 			"dependencies": {
-				"@octokit/types": "^7.5.0"
+				"@octokit/types": "^8.0.0"
 			},
 			"engines": {
 				"node": ">= 14"
@@ -377,11 +377,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "6.6.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
-			"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.7.0.tgz",
+			"integrity": "sha512-orxQ0fAHA7IpYhG2flD2AygztPlGYNAdlzYz8yrD8NDgelPfOYoRPROfEyIe035PlxvbYrgkfUZIhSBKju/Cvw==",
 			"dependencies": {
-				"@octokit/types": "^7.5.0",
+				"@octokit/types": "^8.0.0",
 				"deprecation": "^2.3.1"
 			},
 			"engines": {
@@ -392,13 +392,13 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/request": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
-			"integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
+			"integrity": "sha512-6VDqgj0HMc2FUX2awIs+sM6OwLgwHvAi4KCK3mT2H2IKRt6oH9d0fej5LluF5mck1lRR/rFWN0YIDSYXYSylbw==",
 			"dependencies": {
 				"@octokit/endpoint": "^7.0.0",
 				"@octokit/request-error": "^3.0.0",
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^8.0.0",
 				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.6.7",
 				"universal-user-agent": "^6.0.0"
@@ -408,11 +408,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
-			"integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.2.tgz",
+			"integrity": "sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==",
 			"dependencies": {
-				"@octokit/types": "^7.0.0",
+				"@octokit/types": "^8.0.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			},
@@ -421,11 +421,11 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/types": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
-			"integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+			"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
 			"dependencies": {
-				"@octokit/openapi-types": "^13.11.0"
+				"@octokit/openapi-types": "^14.0.0"
 			}
 		},
 		"node_modules/@octokit/types": {
@@ -556,9 +556,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.8.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+			"version": "18.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
+			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -746,9 +746,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
-			"integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+			"integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -1555,9 +1555,9 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"node_modules/is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -1985,9 +1985,12 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -5442,9 +5445,12 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"node_modules/traverse": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+			"integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/trim-newlines": {
 			"version": "3.0.1",
@@ -5892,109 +5898,109 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "19.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
-			"integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
+			"version": "19.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.5.tgz",
+			"integrity": "sha512-+4qdrUFq2lk7Va+Qff3ofREQWGBeoTKNqlJO+FGjFP35ZahP+nBenhZiGdu8USSgmq4Ky3IJ/i4u0xbLqHaeow==",
 			"requires": {
-				"@octokit/core": "^4.0.0",
-				"@octokit/plugin-paginate-rest": "^4.0.0",
+				"@octokit/core": "^4.1.0",
+				"@octokit/plugin-paginate-rest": "^5.0.0",
 				"@octokit/plugin-request-log": "^1.0.4",
-				"@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+				"@octokit/plugin-rest-endpoint-methods": "^6.7.0"
 			},
 			"dependencies": {
 				"@octokit/auth-token": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
-					"integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.2.tgz",
+					"integrity": "sha512-pq7CwIMV1kmzkFTimdwjAINCXKTajZErLB4wMLYapR2nuB/Jpr66+05wOTZMSCBXP6n4DdDWT2W19Bm17vU69Q==",
 					"requires": {
-						"@octokit/types": "^7.0.0"
+						"@octokit/types": "^8.0.0"
 					}
 				},
 				"@octokit/core": {
-					"version": "4.0.5",
-					"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
-					"integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+					"integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
 					"requires": {
 						"@octokit/auth-token": "^3.0.0",
 						"@octokit/graphql": "^5.0.0",
 						"@octokit/request": "^6.0.0",
 						"@octokit/request-error": "^3.0.0",
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^8.0.0",
 						"before-after-hook": "^2.2.0",
 						"universal-user-agent": "^6.0.0"
 					}
 				},
 				"@octokit/endpoint": {
-					"version": "7.0.2",
-					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.2.tgz",
-					"integrity": "sha512-8/AUACfE9vpRpehE6ZLfEtzkibe5nfsSwFZVMsG8qabqRt1M81qZYUFRZa1B8w8lP6cdfDJfRq9HWS+MbmR7tw==",
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.3.tgz",
+					"integrity": "sha512-57gRlb28bwTsdNXq+O3JTQ7ERmBTuik9+LelgcLIVfYwf235VHbN9QNo4kXExtp/h8T423cR5iJThKtFYxC7Lw==",
 					"requires": {
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^8.0.0",
 						"is-plain-object": "^5.0.0",
 						"universal-user-agent": "^6.0.0"
 					}
 				},
 				"@octokit/graphql": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
-					"integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.4.tgz",
+					"integrity": "sha512-amO1M5QUQgYQo09aStR/XO7KAl13xpigcy/kI8/N1PnZYSS69fgte+xA4+c2DISKqUZfsh0wwjc2FaCt99L41A==",
 					"requires": {
 						"@octokit/request": "^6.0.0",
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^8.0.0",
 						"universal-user-agent": "^6.0.0"
 					}
 				},
 				"@octokit/openapi-types": {
-					"version": "13.13.1",
-					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
-					"integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
+					"version": "14.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+					"integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
 				},
 				"@octokit/plugin-paginate-rest": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.3.1.tgz",
-					"integrity": "sha512-h8KKxESmSFTcXX409CAxlaOYscEDvN2KGQRsLCGT1NSqRW+D6EXLVQ8vuHhFznS9MuH9QYw1GfsUN30bg8hjVA==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-5.0.1.tgz",
+					"integrity": "sha512-7A+rEkS70pH36Z6JivSlR7Zqepz3KVucEFVDnSrgHXzG7WLAzYwcHZbKdfTXHwuTHbkT1vKvz7dHl1+HNf6Qyw==",
 					"requires": {
-						"@octokit/types": "^7.5.0"
+						"@octokit/types": "^8.0.0"
 					}
 				},
 				"@octokit/plugin-rest-endpoint-methods": {
-					"version": "6.6.2",
-					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.6.2.tgz",
-					"integrity": "sha512-n9dL5KMpz9qVFSNdcVWC8ZPbl68QbTk7+CMPXCXqaMZOLn1n1YuoSFFCy84Ge0fx333fUqpnBHv8BFjwGtUQkA==",
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.7.0.tgz",
+					"integrity": "sha512-orxQ0fAHA7IpYhG2flD2AygztPlGYNAdlzYz8yrD8NDgelPfOYoRPROfEyIe035PlxvbYrgkfUZIhSBKju/Cvw==",
 					"requires": {
-						"@octokit/types": "^7.5.0",
+						"@octokit/types": "^8.0.0",
 						"deprecation": "^2.3.1"
 					}
 				},
 				"@octokit/request": {
-					"version": "6.2.1",
-					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
-					"integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
+					"integrity": "sha512-6VDqgj0HMc2FUX2awIs+sM6OwLgwHvAi4KCK3mT2H2IKRt6oH9d0fej5LluF5mck1lRR/rFWN0YIDSYXYSylbw==",
 					"requires": {
 						"@octokit/endpoint": "^7.0.0",
 						"@octokit/request-error": "^3.0.0",
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^8.0.0",
 						"is-plain-object": "^5.0.0",
 						"node-fetch": "^2.6.7",
 						"universal-user-agent": "^6.0.0"
 					}
 				},
 				"@octokit/request-error": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
-					"integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.2.tgz",
+					"integrity": "sha512-WMNOFYrSaX8zXWoJg9u/pKgWPo94JXilMLb2VManNOby9EZxrQaBe/QSC4a1TzpAlpxofg2X/jMnCyZgL6y7eg==",
 					"requires": {
-						"@octokit/types": "^7.0.0",
+						"@octokit/types": "^8.0.0",
 						"deprecation": "^2.0.0",
 						"once": "^1.4.0"
 					}
 				},
 				"@octokit/types": {
-					"version": "7.5.1",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.5.1.tgz",
-					"integrity": "sha512-Zk4OUMLCSpXNI8KZZn47lVLJSsgMyCimsWWQI5hyjZg7hdYm0kjotaIkbG0Pp8SfU2CofMBzonboTqvzn3FrJA==",
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
+					"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
 					"requires": {
-						"@octokit/openapi-types": "^13.11.0"
+						"@octokit/openapi-types": "^14.0.0"
 					}
 				}
 			}
@@ -6097,9 +6103,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.8.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
-			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+			"version": "18.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
+			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6242,9 +6248,9 @@
 			}
 		},
 		"chalk": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.0.tgz",
-			"integrity": "sha512-56zD4khRTBoIyzUYAFgDDaPhUMN/fC/rySe6aZGqbj/VWiU2eI3l6ZLOtYGFZAV5v02mwPjtpzlrOveJiz5eZQ=="
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
+			"integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -6830,9 +6836,9 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
 		},
 		"is-core-module": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-			"integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -7142,9 +7148,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
 		},
 		"minimist-options": {
 			"version": "4.1.0",
@@ -9517,9 +9523,9 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"traverse": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-			"integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+			"integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
 		},
 		"trim-newlines": {
 			"version": "3.0.1",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._