### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -556,9 +556,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
-			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
+			"version": "18.11.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -897,9 +897,9 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/cosmiconfig": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -965,15 +965,18 @@
 			}
 		},
 		"node_modules/decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"dependencies": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/decamelize-keys/node_modules/map-obj": {
@@ -1857,9 +1860,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
-			"integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
+			"integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -2081,9 +2084,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "8.19.2",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+			"version": "8.19.3",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.3.tgz",
+			"integrity": "sha512-0QjmyPtDxSyMWWD8I91QGbrgx9KzbV6C9FK1liEb/K0zppiZkr5KxXc990G+LzPwBHDfRjUBlO9T1qZ08vl9mA==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -2092,7 +2095,6 @@
 				"@npmcli/fs",
 				"@npmcli/map-workspaces",
 				"@npmcli/package-json",
-				"@npmcli/promise-spawn",
 				"@npmcli/run-script",
 				"abbrev",
 				"archy",
@@ -2162,13 +2164,12 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.6.2",
+				"@npmcli/arborist": "^5.6.3",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/promise-spawn": "*",
 				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
@@ -2179,18 +2180,18 @@
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
-				"fs-minipass": "*",
+				"fs-minipass": "^2.1.0",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.1.0",
+				"hosted-git-info": "^5.2.1",
 				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.4",
 				"libnpmdiff": "^4.0.5",
-				"libnpmexec": "^4.0.13",
-				"libnpmfund": "^3.0.4",
+				"libnpmexec": "^4.0.14",
+				"libnpmfund": "^3.0.5",
 				"libnpmhook": "^8.0.4",
 				"libnpmorg": "^4.0.4",
 				"libnpmpack": "^4.1.3",
@@ -2199,7 +2200,7 @@
 				"libnpmteam": "^4.0.4",
 				"libnpmversion": "^3.0.7",
 				"make-fetch-happen": "^10.2.0",
-				"minimatch": "*",
+				"minimatch": "^5.1.0",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -2241,7 +2242,7 @@
 				"npx": "bin/npx-cli.js"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -2275,7 +2276,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "5.6.2",
+			"version": "5.6.3",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -2292,6 +2293,7 @@
 				"bin-links": "^3.0.3",
 				"cacache": "^16.1.3",
 				"common-ancestor-path": "^1.0.1",
+				"hosted-git-info": "^5.2.1",
 				"json-parse-even-better-errors": "^2.3.1",
 				"json-stringify-nice": "^1.1.4",
 				"minimatch": "^5.1.0",
@@ -3031,7 +3033,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "5.1.0",
+			"version": "5.2.1",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -3279,11 +3281,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "4.0.13",
+			"version": "4.0.14",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.6.2",
+				"@npmcli/arborist": "^5.6.3",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/fs": "^2.1.1",
 				"@npmcli/run-script": "^4.2.0",
@@ -3303,11 +3305,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "3.0.4",
+			"version": "3.0.5",
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^5.6.2"
+				"@npmcli/arborist": "^5.6.3"
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -5480,9 +5482,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5493,9 +5495,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-			"integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
 			"optional": true,
 			"bin": {
 				"uglifyjs": "bin/uglifyjs"
@@ -6103,9 +6105,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.11.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.2.tgz",
-			"integrity": "sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==",
+			"version": "18.11.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6363,9 +6365,9 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cosmiconfig": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"requires": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -6408,9 +6410,9 @@
 			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
 		},
 		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
@@ -7063,9 +7065,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.1.1.tgz",
-			"integrity": "sha512-0cNMnTcUJPxbA6uWmCmjWz4NJRe/0Xfk2NhXCUHjew9qJzFN20krFnsUe7QynwqOwa5m1fZ4UDg0ycKFVC0ccw=="
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
+			"integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -7215,18 +7217,17 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
 		},
 		"npm": {
-			"version": "8.19.2",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.2.tgz",
-			"integrity": "sha512-MWkISVv5f7iZbfNkry5/5YBqSYJEDAKSJdL+uzSQuyLg+hgLQUyZynu3SH6bOZlvR9ZvJYk2EiJO6B1r+ynwHg==",
+			"version": "8.19.3",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-8.19.3.tgz",
+			"integrity": "sha512-0QjmyPtDxSyMWWD8I91QGbrgx9KzbV6C9FK1liEb/K0zppiZkr5KxXc990G+LzPwBHDfRjUBlO9T1qZ08vl9mA==",
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^5.6.2",
+				"@npmcli/arborist": "^5.6.3",
 				"@npmcli/ci-detect": "^2.0.0",
 				"@npmcli/config": "^4.2.1",
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/map-workspaces": "^2.0.3",
 				"@npmcli/package-json": "^2.0.0",
-				"@npmcli/promise-spawn": "*",
 				"@npmcli/run-script": "^4.2.1",
 				"abbrev": "~1.1.1",
 				"archy": "~1.0.0",
@@ -7237,18 +7238,18 @@
 				"cli-table3": "^0.6.2",
 				"columnify": "^1.6.0",
 				"fastest-levenshtein": "^1.0.12",
-				"fs-minipass": "*",
+				"fs-minipass": "^2.1.0",
 				"glob": "^8.0.1",
 				"graceful-fs": "^4.2.10",
-				"hosted-git-info": "^5.1.0",
+				"hosted-git-info": "^5.2.1",
 				"ini": "^3.0.1",
 				"init-package-json": "^3.0.2",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
 				"libnpmaccess": "^6.0.4",
 				"libnpmdiff": "^4.0.5",
-				"libnpmexec": "^4.0.13",
-				"libnpmfund": "^3.0.4",
+				"libnpmexec": "^4.0.14",
+				"libnpmfund": "^3.0.5",
 				"libnpmhook": "^8.0.4",
 				"libnpmorg": "^4.0.4",
 				"libnpmpack": "^4.1.3",
@@ -7257,7 +7258,7 @@
 				"libnpmteam": "^4.0.4",
 				"libnpmversion": "^3.0.7",
 				"make-fetch-happen": "^10.2.0",
-				"minimatch": "*",
+				"minimatch": "^5.1.0",
 				"minipass": "^3.1.6",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -7309,7 +7310,7 @@
 					"bundled": true
 				},
 				"@npmcli/arborist": {
-					"version": "5.6.2",
+					"version": "5.6.3",
 					"bundled": true,
 					"requires": {
 						"@isaacs/string-locale-compare": "^1.1.0",
@@ -7325,6 +7326,7 @@
 						"bin-links": "^3.0.3",
 						"cacache": "^16.1.3",
 						"common-ancestor-path": "^1.0.1",
+						"hosted-git-info": "^5.2.1",
 						"json-parse-even-better-errors": "^2.3.1",
 						"json-stringify-nice": "^1.1.4",
 						"minimatch": "^5.1.0",
@@ -7829,7 +7831,7 @@
 					"bundled": true
 				},
 				"hosted-git-info": {
-					"version": "5.1.0",
+					"version": "5.2.1",
 					"bundled": true,
 					"requires": {
 						"lru-cache": "^7.5.1"
@@ -7998,10 +8000,10 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "4.0.13",
+					"version": "4.0.14",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.6.2",
+						"@npmcli/arborist": "^5.6.3",
 						"@npmcli/ci-detect": "^2.0.0",
 						"@npmcli/fs": "^2.1.1",
 						"@npmcli/run-script": "^4.2.0",
@@ -8018,10 +8020,10 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "3.0.4",
+					"version": "3.0.5",
 					"bundled": true,
 					"requires": {
-						"@npmcli/arborist": "^5.6.2"
+						"@npmcli/arborist": "^5.6.3"
 					}
 				},
 				"libnpmhook": {
@@ -9543,15 +9545,15 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.8.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"version": "4.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.17.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-			"integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
 			"optional": true
 		},
 		"unique-string": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._