### PR TITLE
chore: update dependency tree

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,21 +2,24 @@
 version: 2
 updates:
   # Enable version updates for npm
-  - package-ecosystem: 'npm'
+  - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
+    directory: "/"
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'daily'
+      interval: "daily"
     commit-message:
-      prefix: 'fix'
-      prefix-development: 'build'
-      include: 'scope'
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: [version-update:semver-minor, version-update:semver-patch]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: 'fix'
-      prefix-development: 'build'
-      include: 'scope'
+      prefix: "fix"
+      prefix-development: "build"
+      include: "scope"

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,4 +22,3 @@ jobs:
           client-cert: ${{ secrets.MTLS_CERT }}
           client-key: ${{ secrets.MTLS_KEY }}
           token: ${{ secrets.SONAR_TOKEN }}
-          host: 'https://sonar.ts.sv'

--- a/package-lock.json
+++ b/package-lock.json
@@ -465,9 +465,9 @@
 			}
 		},
 		"node_modules/@semantic-release/github": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
-			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.7.tgz",
+			"integrity": "sha512-VtgicRIKGvmTHwm//iqTh/5NGQwsncOMR5vQK9pMT92Aem7dv37JFKKRuulUsAnUOIlO4G8wH3gPiBAA0iW0ww==",
 			"dependencies": {
 				"@octokit/rest": "^19.0.0",
 				"@semantic-release/error": "^3.0.0",
@@ -475,7 +475,7 @@
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
 				"dir-glob": "^3.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^11.0.0",
 				"globby": "^11.0.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -519,6 +519,19 @@
 				"semantic-release": ">=19.0.0"
 			}
 		},
+		"node_modules/@semantic-release/npm/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@semantic-release/release-notes-generator": {
 			"version": "10.0.3",
 			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
@@ -556,9 +569,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -746,9 +759,9 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
-			"integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -1157,9 +1170,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -1244,16 +1257,16 @@
 			]
 		},
 		"node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+			"integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
 				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -1469,9 +1482,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -1860,9 +1873,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-			"integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw==",
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+			"integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -5482,9 +5495,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -6035,9 +6048,9 @@
 			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
 		},
 		"@semantic-release/github": {
-			"version": "8.0.6",
-			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.6.tgz",
-			"integrity": "sha512-ZxgaxYCeqt9ylm2x3OPqUoUqBw1p60LhxzdX6BqJlIBThupGma98lttsAbK64T6L6AlNa2G5T66BbiG8y0PIHQ==",
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.7.tgz",
+			"integrity": "sha512-VtgicRIKGvmTHwm//iqTh/5NGQwsncOMR5vQK9pMT92Aem7dv37JFKKRuulUsAnUOIlO4G8wH3gPiBAA0iW0ww==",
 			"requires": {
 				"@octokit/rest": "^19.0.0",
 				"@semantic-release/error": "^3.0.0",
@@ -6045,7 +6058,7 @@
 				"bottleneck": "^2.18.1",
 				"debug": "^4.0.0",
 				"dir-glob": "^3.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^11.0.0",
 				"globby": "^11.0.0",
 				"http-proxy-agent": "^5.0.0",
 				"https-proxy-agent": "^5.0.0",
@@ -6075,6 +6088,18 @@
 				"registry-auth-token": "^4.0.0",
 				"semver": "^7.1.2",
 				"tempy": "^1.0.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@semantic-release/release-notes-generator": {
@@ -6105,9 +6130,9 @@
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
 		},
 		"@types/node": {
-			"version": "18.11.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-			"integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+			"version": "18.11.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+			"integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6250,9 +6275,9 @@
 			}
 		},
 		"chalk": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.1.2.tgz",
-			"integrity": "sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",
@@ -6551,9 +6576,9 @@
 			}
 		},
 		"fastq": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"requires": {
 				"reusify": "^1.0.4"
 			}
@@ -6606,9 +6631,9 @@
 			"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg=="
 		},
 		"fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+			"integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
 			"requires": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -6774,9 +6799,9 @@
 			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
 		},
 		"ignore": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ=="
 		},
 		"import-fresh": {
 			"version": "3.3.0",
@@ -7065,9 +7090,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.3.tgz",
-			"integrity": "sha512-slWRdJkbTZ+PjkyJnE30Uid64eHwbwa1Q25INCAYfZlK4o6ylagBy/Le9eWntqJFoFT93ikUKMv47GZ4gTwHkw=="
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+			"integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -9545,9 +9570,9 @@
 			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 		},
 		"typescript": {
-			"version": "4.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-			"integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+			"version": "4.9.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+			"integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
 			"dev": true
 		},
 		"uglify-js": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._