### PR TITLE
chore: update dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -421,9 +421,9 @@
 			}
 		},
 		"node_modules/@octokit/rest/node_modules/@octokit/types": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
-			"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.1.1.tgz",
+			"integrity": "sha512-7tjk+6DyhYAmei8FOEwPfGKc0VE1x56CKPJ+eE44zhDbOyMT+9yan8apfQFxo8oEFsy+0O7PiBtH8w0Yo0Y9Kw==",
 			"dependencies": {
 				"@octokit/openapi-types": "^14.0.0"
 			}
@@ -434,6 +434,29 @@
 			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
 			"dependencies": {
 				"@octokit/openapi-types": "^12.11.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"dependencies": {
+				"graceful-fs": "4.2.10"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/npm-conf": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-1.0.5.tgz",
+			"integrity": "sha512-hD8ml183638O3R6/Txrh0L8VzGOrFXgRtRDG4qQC4tONdZ5Z1M+tlUUDUvrjYdmK6G+JTBTeaCLMna11cXzi8A==",
+			"dependencies": {
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@semantic-release/commit-analyzer": {
@@ -494,21 +517,21 @@
 			}
 		},
 		"node_modules/@semantic-release/npm": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-			"integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+			"integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
 			"dependencies": {
 				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"execa": "^5.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^11.0.0",
 				"lodash": "^4.17.15",
 				"nerf-dart": "^1.0.0",
 				"normalize-url": "^6.0.0",
 				"npm": "^8.3.0",
 				"rc": "^1.2.8",
 				"read-pkg": "^5.0.0",
-				"registry-auth-token": "^4.0.0",
+				"registry-auth-token": "^5.0.0",
 				"semver": "^7.1.2",
 				"tempy": "^1.0.0"
 			},
@@ -517,19 +540,6 @@
 			},
 			"peerDependencies": {
 				"semantic-release": ">=19.0.0"
-			}
-		},
-		"node_modules/@semantic-release/npm/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@semantic-release/release-notes-generator": {
@@ -830,6 +840,15 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
 		},
 		"node_modules/conventional-changelog-angular": {
 			"version": "5.0.13",
@@ -1873,9 +1892,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-			"integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+			"integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -2053,9 +2072,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+			"integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -4737,6 +4756,11 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+		},
 		"node_modules/q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -4892,14 +4916,14 @@
 			}
 		},
 		"node_modules/registry-auth-token": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
-			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.1.tgz",
+			"integrity": "sha512-UfxVOj8seK1yaIOiieV4FIP01vfBDLsY0H9sQzi9EbbUdJiuuBjJgLa1DpImXMNPnVkBD4eVxTEXcrZA6kfpJA==",
 			"dependencies": {
-				"rc": "1.2.8"
+				"@pnpm/npm-conf": "^1.0.4"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=14"
 			}
 		},
 		"node_modules/require-directory": {
@@ -6011,9 +6035,9 @@
 					}
 				},
 				"@octokit/types": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.0.0.tgz",
-					"integrity": "sha512-65/TPpOJP1i3K4lBJMnWqPUJ6zuOtzhtagDvydAWbEXpbFYA0oMKKyLb95NFZZP0lSh/4b6K+DQlzvYQJQQePg==",
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.1.1.tgz",
+					"integrity": "sha512-7tjk+6DyhYAmei8FOEwPfGKc0VE1x56CKPJ+eE44zhDbOyMT+9yan8apfQFxo8oEFsy+0O7PiBtH8w0Yo0Y9Kw==",
 					"requires": {
 						"@octokit/openapi-types": "^14.0.0"
 					}
@@ -6026,6 +6050,23 @@
 			"integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
 			"requires": {
 				"@octokit/openapi-types": "^12.11.0"
+			}
+		},
+		"@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"requires": {
+				"graceful-fs": "4.2.10"
+			}
+		},
+		"@pnpm/npm-conf": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-1.0.5.tgz",
+			"integrity": "sha512-hD8ml183638O3R6/Txrh0L8VzGOrFXgRtRDG4qQC4tONdZ5Z1M+tlUUDUvrjYdmK6G+JTBTeaCLMna11cXzi8A==",
+			"requires": {
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
 			}
 		},
 		"@semantic-release/commit-analyzer": {
@@ -6071,35 +6112,23 @@
 			}
 		},
 		"@semantic-release/npm": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-			"integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
+			"integrity": "sha512-zgsynF6McdzxPnFet+a4iO9HpAlARXOM5adz7VGVCvj0ne8wtL2ZOQoDV2wZPDmdEotDIbVeJjafhelZjs9j6g==",
 			"requires": {
 				"@semantic-release/error": "^3.0.0",
 				"aggregate-error": "^3.0.0",
 				"execa": "^5.0.0",
-				"fs-extra": "^10.0.0",
+				"fs-extra": "^11.0.0",
 				"lodash": "^4.17.15",
 				"nerf-dart": "^1.0.0",
 				"normalize-url": "^6.0.0",
 				"npm": "^8.3.0",
 				"rc": "^1.2.8",
 				"read-pkg": "^5.0.0",
-				"registry-auth-token": "^4.0.0",
+				"registry-auth-token": "^5.0.0",
 				"semver": "^7.1.2",
 				"tempy": "^1.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-					"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^6.0.1",
-						"universalify": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@semantic-release/release-notes-generator": {
@@ -6329,6 +6358,15 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+		},
+		"config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
 		},
 		"conventional-changelog-angular": {
 			"version": "5.0.13",
@@ -7090,9 +7128,9 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
 		},
 		"marked": {
-			"version": "4.2.5",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-			"integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ=="
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+			"integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
 		},
 		"marked-terminal": {
 			"version": "5.1.1",
@@ -7218,9 +7256,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+			"integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			}
@@ -9014,6 +9052,11 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -9128,11 +9171,11 @@
 			}
 		},
 		"registry-auth-token": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.2.tgz",
-			"integrity": "sha512-PC5ZysNb42zpFME6D/XlIgtNGdTl8bBOCw90xQLVMpzuuubJKYDWFAEuUNc+Cn8Z8724tg2SDhDRrkVEsqfDMg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.1.tgz",
+			"integrity": "sha512-UfxVOj8seK1yaIOiieV4FIP01vfBDLsY0H9sQzi9EbbUdJiuuBjJgLa1DpImXMNPnVkBD4eVxTEXcrZA6kfpJA==",
 			"requires": {
-				"rc": "1.2.8"
+				"@pnpm/npm-conf": "^1.0.4"
 			}
 		},
 		"require-directory": {


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._