### PR TITLE
Rewrite to ESM to support semantic-release 20

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,26 @@
-const path = require('path');
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
+import path from "path";
+import util from "util";
+import { exec as nodeExec } from "child_process";
+
+const exec = util.promisify(nodeExec);
 
 const run = async () => {
-	// Install Dependencies
-	{
-		const { stdout, stderr } = await exec('npm ci --only=prod --silent', {
-			cwd: path.resolve(__dirname),
-		});
-		console.log(stdout);
-		if (stderr) {
-			return Promise.reject(stderr);
-		}
-	}
+  // Install Dependencies
+  {
+    const __dirname = new URL(".", import.meta.url).pathname;
+    const { stdout, stderr } = await exec("npm ci --only=prod --silent", {
+      cwd: path.resolve(__dirname),
+    });
+    console.log(stdout);
+    if (stderr) {
+      return Promise.reject(stderr);
+    }
+  }
 
-	require('./src/index')();
+  (await import("./src/index.js")).run();
 };
 
-run().catch(console.error);
+run().catch((err) => {
+  process.exitCode = 1;
+  console.error(err);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"semantic-release": "20.0.2"
 			},
 			"devDependencies": {
-				"@types/node": "18.11.18",
+				"@types/node": "^18.11.18",
 				"typescript": "4.9.4"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,29 +1,30 @@
 {
-	"name": "@tradeshift/actions-semantic-release",
-	"version": "1.0.0",
-	"description": "",
-	"main": "index.js",
-	"scripts": {
-		"validate": "tsc"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/tradeshift/actions-semantic-release.git"
-	},
-	"keywords": [],
-	"author": "Jacob Wejendorp <jwe@tradeshift.com>",
-	"bugs": {
-		"url": "https://github.com/tradeshift/actions-semantic-release/issues"
-	},
-	"homepage": "https://github.com/tradeshift/actions-semantic-release#readme",
-	"dependencies": {
-		"@actions/core": "1.10.0",
-		"@actions/exec": "1.1.1",
-		"@actions/github": "5.1.1",
-		"semantic-release": "20.0.2"
-	},
-	"devDependencies": {
-		"@types/node": "18.11.18",
-		"typescript": "4.9.4"
-	}
+  "name": "@tradeshift/actions-semantic-release",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "validate": "tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tradeshift/actions-semantic-release.git"
+  },
+  "keywords": [],
+  "author": "Jacob Wejendorp <jwe@tradeshift.com>",
+  "bugs": {
+    "url": "https://github.com/tradeshift/actions-semantic-release/issues"
+  },
+  "homepage": "https://github.com/tradeshift/actions-semantic-release#readme",
+  "dependencies": {
+    "@actions/core": "1.10.0",
+    "@actions/exec": "1.1.1",
+    "@actions/github": "5.1.1",
+    "semantic-release": "20.0.2"
+  },
+  "devDependencies": {
+    "@types/node": "^18.11.18",
+    "typescript": "4.9.4"
+  }
 }

--- a/src/handleOptions.js
+++ b/src/handleOptions.js
@@ -1,59 +1,59 @@
-const core = require('@actions/core');
-const inputs = require('./inputs.json');
+import core from "@actions/core";
+import inputs from "./inputs.js";
 
 /**
  * Handle Branches Option
  * @returns {{}|{branch: string}}
  */
-exports.handleBranchesOption = () => {
-	const branchesOption = {};
-	const branches = core.getInput(inputs.branches);
-	const branch = core.getInput(inputs.branch);
+export const handleBranchesOption = () => {
+  const branchesOption = {};
+  const branches = core.getInput(inputs.branches);
+  const branch = core.getInput(inputs.branch);
 
-	core.debug(`branches input: ${branches}`);
-	core.debug(`branch input: ${branch}`);
+  core.debug(`branches input: ${branches}`);
+  core.debug(`branch input: ${branch}`);
 
-	// semantic-version > 16 compat
-	const strNeedConvertToJson = branches || branch || '';
+  // semantic-version > 16 compat
+  const strNeedConvertToJson = branches || branch || "";
 
-	if (!strNeedConvertToJson) {
-		return branchesOption;
-	}
+  if (!strNeedConvertToJson) {
+    return branchesOption;
+  }
 
-	// use eval instead of JSON.parse to allow single quotes
-	const jsonOrStr = eval('' + strNeedConvertToJson);
-	core.debug(`Converted branches attribute: ${JSON.stringify(jsonOrStr)}`);
-	branchesOption.branches = jsonOrStr;
-	return branchesOption;
+  // use eval instead of JSON.parse to allow single quotes
+  const jsonOrStr = eval("" + strNeedConvertToJson);
+  core.debug(`Converted branches attribute: ${JSON.stringify(jsonOrStr)}`);
+  branchesOption.branches = jsonOrStr;
+  return branchesOption;
 };
 
 /**
  * Handle DryRun Option
  */
-exports.handleDryRunOption = () => {
-	const dryRun = core.getInput(inputs.dry_run);
+export const handleDryRunOption = () => {
+  const dryRun = core.getInput(inputs.dry_run);
 
-	switch (dryRun) {
-		case 'true':
-			// skip CI check in dry run mode
-			return { dryRun: true, noCi: true };
+  switch (dryRun) {
+    case "true":
+      // skip CI check in dry run mode
+      return { dryRun: true, noCi: true };
 
-		case 'false':
-		default:
-			return { dryRun: false };
-	}
+    case "false":
+    default:
+      return { dryRun: false };
+  }
 };
 
 /**
  * Handle Extends Option
  * @returns {{}|{extends: Array}|{extends: String}}
  */
-exports.handleExtends = () => {
-	const extend = core.getInput(inputs.extends);
+export const handleExtends = () => {
+  const extend = core.getInput(inputs.extends);
 
-	if (extend) {
-		return { extends: extend };
-	} else {
-		return {};
-	}
+  if (extend) {
+    return { extends: extend };
+  } else {
+    return {};
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,15 @@
-const fs = require('fs');
-const path = require('path');
-const core = require('@actions/core');
-const github = require('@actions/github');
-const {
-	handleBranchesOption,
-	handleDryRunOption,
-	handleExtends,
-} = require('./handleOptions');
-const outputs = require('./outputs.json');
-const inputs = require('./inputs.json');
+import fs from "fs";
+import path from "path";
+import core from "@actions/core";
+import github from "@actions/github";
+import {
+  handleBranchesOption,
+  handleDryRunOption,
+  handleExtends,
+} from "./handleOptions.js";
+import outputs from "./outputs.js";
+import inputs from "./inputs.js";
+
 /**
  * @typedef {import('semantic-release').Result} Result
  */
@@ -18,146 +19,148 @@ const inputs = require('./inputs.json');
  * @returns {Promise<void>}
  */
 const release = async () => {
-	core.setOutput(outputs.new_release_published, 'false');
+  core.setOutput(outputs.new_release_published, "false");
 
-	const semanticRelease = require('semantic-release');
-	if (handleDryRunOption().dryRun) {
-		// make semantic-release believe we're running on master
-		process.env.GITHUB_EVENT_NAME = 'totally-not-a-pr';
-		process.env.GITHUB_REF = 'master';
-	}
-	const npmPublish = core.getInput(inputs.npm_publish) === 'true';
-	const registry =
-		core.getInput(inputs.registry) || 'https://registry.npmjs.com/';
+  const { default: semanticRelease } = await import("semantic-release");
+  if (handleDryRunOption().dryRun) {
+    // make semantic-release believe we're running on master
+    process.env.GITHUB_EVENT_NAME = "totally-not-a-pr";
+    process.env.GITHUB_REF = "master";
+  }
+  const npmPublish = core.getInput(inputs.npm_publish) === "true";
+  const registry =
+    core.getInput(inputs.registry) || "https://registry.npmjs.com/";
 
-	/** @type {(string | [string, any])[]} */
-	const plugins = [
-		'@semantic-release/commit-analyzer',
-		'@semantic-release/release-notes-generator',
-		'@semantic-release/github',
-	];
-	// only use npm plugin if there is a package.json, or if publish flag is on
-	if (
-		fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, 'package.json')) ||
-		npmPublish
-	) {
-		plugins.push([
-			'@semantic-release/npm',
-			{
-				npmPublish,
-			},
-		]);
-	}
-	process.env.NPM_CONFIG_REGISTRY = registry;
-	// remap NODE_AUTH_TOKEN to NPM_TOKEN, in case action runs without
-	// the actions/setup-node step before it.
-	if (process.env.NODE_AUTH_TOKEN && !process.env.NPM_TOKEN) {
-		process.env.NPM_TOKEN = process.env.NODE_AUTH_TOKEN;
-	}
+  /** @type {(string | [string, any])[]} */
+  const plugins = [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+  ];
+  // only use npm plugin if there is a package.json, or if publish flag is on
+  if (
+    fs.existsSync(path.join(process.env.GITHUB_WORKSPACE, "package.json")) ||
+    npmPublish
+  ) {
+    plugins.push([
+      "@semantic-release/npm",
+      {
+        npmPublish,
+      },
+    ]);
+  }
+  process.env.NPM_CONFIG_REGISTRY = registry;
+  // remap NODE_AUTH_TOKEN to NPM_TOKEN, in case action runs without
+  // the actions/setup-node step before it.
+  if (process.env.NODE_AUTH_TOKEN && !process.env.NPM_TOKEN) {
+    process.env.NPM_TOKEN = process.env.NODE_AUTH_TOKEN;
+  }
 
-	const result = await semanticRelease({
-		...handleBranchesOption(),
-		...handleDryRunOption(),
-		...handleExtends(),
-		plugins,
-	});
+  const result = await semanticRelease({
+    ...handleBranchesOption(),
+    ...handleDryRunOption(),
+    ...handleExtends(),
+    plugins,
+  });
 
-	await collectOutput(result);
-	await updateStatus(result);
+  await collectOutput(result);
+  await updateStatus(result);
 };
 
 const updateStatus = async (/** @type {Result} */ result) => {
-	const checkName = core.getInput(inputs.check_name);
+  const checkName = core.getInput(inputs.check_name);
 
-	if (!checkName) {
-		return;
-	}
+  if (!checkName) {
+    return;
+  }
 
-	const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
-	const [gitHubRepoOwner, gitHubRepoName] =
-		process.env.GITHUB_REPOSITORY.split('/');
+  const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+  const [gitHubRepoOwner, gitHubRepoName] =
+    process.env.GITHUB_REPOSITORY.split("/");
 
-	//
-	let gitHubSha = process.env.GITHUB_SHA;
-	try {
-		const event = require(process.env.GITHUB_EVENT_PATH);
-		gitHubSha = event.pull_request.head.sha;
-	} catch (e) {
-		core.debug('Could not get PR sha, using env.GITHUB_SHA for status');
-	}
+  //
+  let gitHubSha = process.env.GITHUB_SHA;
+  try {
+    const event = JSON.parse(
+      fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf-8")
+    );
+    gitHubSha = event.pull_request.head.sha;
+  } catch (e) {
+    core.debug("Could not get PR sha, using env.GITHUB_SHA for status");
+  }
 
-	const linkToCommitStyle =
-		'[conventional](https://www.conventionalcommits.org/) [commits](https://github.com/semantic-release/semantic-release#how-does-it-work)';
-	let title = 'No new release';
-	let summary = `No new release will be published. Add some ${linkToCommitStyle} if you intend to release these changes.`;
-	if (result && result.nextRelease) {
-		title = `${result.nextRelease.type.replace(/^./, (s) =>
-			s.toUpperCase()
-		)} release (${result.nextRelease.version})`;
-		summary = [
-			`Found the following ${linkToCommitStyle} to trigger a ${result.nextRelease.type} release.`,
-			result.nextRelease.notes,
-		].join('\n\n');
-	}
+  const linkToCommitStyle =
+    "[conventional](https://www.conventionalcommits.org/) [commits](https://github.com/semantic-release/semantic-release#how-does-it-work)";
+  let title = "No new release";
+  let summary = `No new release will be published. Add some ${linkToCommitStyle} if you intend to release these changes.`;
+  if (result && result.nextRelease) {
+    title = `${result.nextRelease.type.replace(/^./, (s) =>
+      s.toUpperCase()
+    )} release (${result.nextRelease.version})`;
+    summary = [
+      `Found the following ${linkToCommitStyle} to trigger a ${result.nextRelease.type} release.`,
+      result.nextRelease.notes,
+    ].join("\n\n");
+  }
 
-	await octokit.rest.checks.create({
-		owner: gitHubRepoOwner,
-		repo: gitHubRepoName,
-		name: checkName,
-		head_sha: gitHubSha,
-		status: 'completed',
-		conclusion: 'success',
-		output: {
-			title,
-			summary,
-		},
-	});
+  await octokit.rest.checks.create({
+    owner: gitHubRepoOwner,
+    repo: gitHubRepoName,
+    name: checkName,
+    head_sha: gitHubSha,
+    status: "completed",
+    conclusion: "success",
+    output: {
+      title,
+      summary,
+    },
+  });
 };
 
 const collectOutput = async (result) => {
-	if (!result) {
-		core.debug('No release published.');
-		return Promise.resolve();
-	}
+  if (!result) {
+    core.debug("No release published.");
+    return Promise.resolve();
+  }
 
-	const { lastRelease, commits, nextRelease, releases } = result;
+  const { lastRelease, commits, nextRelease, releases } = result;
 
-	if (!nextRelease) {
-		core.debug('No release published.');
-		return Promise.resolve();
-	}
+  if (!nextRelease) {
+    core.debug("No release published.");
+    return Promise.resolve();
+  }
 
-	core.debug(
-		`Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`
-	);
+  core.debug(
+    `Published ${nextRelease.type} release version ${nextRelease.version} containing ${commits.length} commits.`
+  );
 
-	if (lastRelease.version) {
-		core.debug(`The last release was "${lastRelease.version}".`);
-	}
+  if (lastRelease.version) {
+    core.debug(`The last release was "${lastRelease.version}".`);
+  }
 
-	for (const release of releases) {
-		core.debug(
-			`The release was published with plugin "${release.pluginName}".`
-		);
-	}
+  for (const release of releases) {
+    core.debug(
+      `The release was published with plugin "${release.pluginName}".`
+    );
+  }
 
-	const { version, channel, notes } = nextRelease;
-	const [major, minor, patch] = version.split(/\.|-|\s/g, 3);
+  const { version, channel, notes } = nextRelease;
+  const [major, minor, patch] = version.split(/\.|-|\s/g, 3);
 
-	// set outputs
-	core.setOutput(outputs.new_release_published, 'true');
-	core.setOutput(outputs.new_release_version, version);
-	core.setOutput(outputs.new_release_major_version, major);
-	core.setOutput(outputs.new_release_minor_version, minor);
-	core.setOutput(outputs.new_release_patch_version, patch);
-	core.setOutput(outputs.new_release_channel, channel);
-	core.setOutput(outputs.new_release_notes, notes);
+  // set outputs
+  core.setOutput(outputs.new_release_published, "true");
+  core.setOutput(outputs.new_release_version, version);
+  core.setOutput(outputs.new_release_major_version, major);
+  core.setOutput(outputs.new_release_minor_version, minor);
+  core.setOutput(outputs.new_release_patch_version, patch);
+  core.setOutput(outputs.new_release_channel, channel);
+  core.setOutput(outputs.new_release_notes, notes);
 };
 
-module.exports = () => {
-	core.debug('Initialization successful');
-	release().catch((err) => {
-		console.error(err);
-		core.setFailed('Failed to run semantic-release');
-	});
+export const run = () => {
+  core.debug("Initialization successful");
+  release().catch((err) => {
+    console.error(err);
+    core.setFailed("Failed to run semantic-release");
+  });
 };

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -1,0 +1,9 @@
+export default {
+  branches: "branches",
+  branch: "branch",
+  dry_run: "dry_run",
+  extends: "extends",
+  registry: "registry",
+  npm_publish: "npm_publish",
+  check_name: "check_name",
+};

--- a/src/inputs.json
+++ b/src/inputs.json
@@ -1,9 +1,0 @@
-{
-	"branches": "branches",
-	"branch": "branch",
-	"dry_run": "dry_run",
-	"extends": "extends",
-	"registry": "registry",
-	"npm_publish": "npm_publish",
-	"check_name": "check_name"
-}

--- a/src/outputs.js
+++ b/src/outputs.js
@@ -1,0 +1,9 @@
+export default {
+  new_release_published: "new_release_published",
+  new_release_version: "new_release_version",
+  new_release_major_version: "new_release_major_version",
+  new_release_minor_version: "new_release_minor_version",
+  new_release_patch_version: "new_release_patch_version",
+  new_release_channel: "new_release_channel",
+  new_release_notes: "new_release_notes",
+};

--- a/src/outputs.json
+++ b/src/outputs.json
@@ -1,9 +1,0 @@
-{
-	"new_release_published": "new_release_published",
-	"new_release_version": "new_release_version",
-	"new_release_major_version": "new_release_major_version",
-	"new_release_minor_version": "new_release_minor_version",
-	"new_release_patch_version": "new_release_patch_version",
-	"new_release_channel": "new_release_channel",
-	"new_release_notes": "new_release_notes"
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": ["ES2015"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
semantic-release v20 ships as ESM, so we need to be compatible.
Might as well do a rewrite for future.