### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 
-*                       @Tradeshift/developer-productivity @Tradeshift/ci-workers
+*                       @Tradeshift/sre @Tradeshift/ci-workers

--- a/Repofile
+++ b/Repofile
@@ -3,7 +3,7 @@
         "Build and test"
     ],
     "maintainers": [
-        "developer-productivity"
+        "sre"
     ],
     "topics": [
         "github-action",

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: other
   lifecycle: production
-  owner: 'developer-productivity'
+  owner: 'sre'


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.