### PR TITLE
chore: ignore semantic-release updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,12 @@
   "extends": [
     "Tradeshift/renovate-config:config-github-action",
     "local>Tradeshift/renovate-config:automerge-dev-deps"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["semantic-release"],
+      "matchManagers": ["npm"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
Otherwise, we'll break applications with package-lock.json files generated with npm < v9