### PR TITLE
Add Tradeshift/legacy-commiters as code reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # The last matching pattern takes precedence.
 # https://help.github.com/articles/about-codeowners/
 
-*                       @Tradeshift/sre @Tradeshift/ci-workers
+*                       @Tradeshift/sre @Tradeshift/ci-workers @Tradeshift/legacy-commiters


### PR DESCRIPTION
This PR updates the CODEOWNERS file to include the Tradeshift/legacy-commiters team as code reviewers.